### PR TITLE
EXLM-94: exl table converter

### DIFF
--- a/src/modules/ExlMd2Html.js
+++ b/src/modules/ExlMd2Html.js
@@ -16,6 +16,7 @@ import createBadge from './blocks/create-badge.js';
 import createRelatedArticles from './blocks/create-article.js';
 import createNote from './blocks/create-note.js';
 import createTabs from './blocks/create-tabs.js';
+import createTable from './blocks/create-table.js';
 
 // attempt to make table blocks by adding a heading to each table with value "Table"
 // in hopes that the html pipeline will maintain them as tables
@@ -62,7 +63,7 @@ function converter(mdString) {
   const hast = h('html', [
     h('body', [
       h('header', []),
-      h('main', [h('div', content.hast)]),
+      h('main', content.hast),
       h('footer', []),
     ]),
   ]);
@@ -83,6 +84,7 @@ function converter(mdString) {
   createRelatedArticles(document);
   createNote(document);
   createTabs(document);
+  createTable(document);
 
   return dom.serialize();
 }

--- a/src/modules/blocks/create-table.js
+++ b/src/modules/blocks/create-table.js
@@ -1,0 +1,40 @@
+import * as WebImporter from '@adobe/helix-importer';
+
+
+export default function createTable(document) {
+
+    /*
+        replace all below elements with divs and add class="table" as shown below
+        <table>   to  <div class="table"> 
+            <thead>
+                <tr><th>innerHTML</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>innerHTML</td></tr>
+            </tbody>
+        </table>
+    */
+
+    const tableElements = Array.from(document.getElementsByTagName("table"));
+    tableElements.forEach(function (element) {
+
+        const tableElement = element.cloneNode(true);
+        const divTable = document.createElement('div');
+        divTable.classList.add('table');
+
+        const tabRows = Array.from(tableElement.rows);
+        tabRows.forEach(function (tabRow) {
+            let trDiv = document.createElement('div');
+            const cells = Array.from(tabRow.cells);
+            cells.forEach(function (cell) {
+                let tdDiv = document.createElement('div');
+                tdDiv.innerHTML = cell.innerHTML;
+                trDiv.appendChild(tdDiv);
+            })
+            divTable.appendChild(trDiv);
+
+        });
+
+        element.parentNode.replaceChild(divTable, element);
+    });
+}

--- a/src/url-mapping.js
+++ b/src/url-mapping.js
@@ -35,4 +35,20 @@ export default [
     path: '/docs/authoring-guide-exl/using/markdown/syntax-style-guide',
     id: 'rec9WkO4eYWupFTrM',
   },
+  {
+    path: "/docs/integrations-learn/experience-cloud/integrations-between-applications/acrobat-sign/acrobat-sign-experience-manager",
+    id: "rec8kVXIkl6bf1Vl0"
+  },
+  {
+    path: "/docs/integrations-learn/experience-cloud/integrations-between-applications/experience-manager/workfront-creative-cloud",
+    id: "recriI7ggpfPIdQWg"
+  },
+  {
+    path: "/docs/experience-platform/tags/term-updates",
+    id: "rechzX4XMu9NbvH0P"
+  },
+  {
+    path: "/docs/experience-platform/collection/visitor-identification/visitor-identification",
+    id: "recU6P6MFEqCjHh0R"
+  }
 ];


### PR DESCRIPTION
EXLM-94: add table converter.
Change from h('main', [h('div', content.hast)]) to  h('main', content.hast) is needed as that extra nested DIV seem to confuse the hlx pipeline and produce very different results - <p> elements instead of table block.
