### PR TITLE
EXLM-172 - Convert all nested blocks into tables

### DIFF
--- a/express.js
+++ b/express.js
@@ -21,7 +21,7 @@ const handler = (req, res) => {
     ...query,
   };
 
-  render(path, params).then(({ html, md, error }) => {
+  render(path, params).then(({ html, md, original, error }) => {
     if (error) {
       res.status(error.code || 503);
       res.send(error.message);
@@ -31,8 +31,11 @@ const handler = (req, res) => {
     if (path.endsWith('.md')) {
       res.setHeader('Content-Type', 'text/plain');
       res.send(md);
+    } else if (path.endsWith('.original')) {
+      res.send(original);
+    } else {
+      res.send(html);
     }
-    res.send(html);
   });
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,12 @@ const renderDoc = async function renderDocs(path) {
     // ExL API does not provide a way to lookup by path, so for now, we hard code it.
     const response = await exlClient.getArticle(id);
     const md = response.data.FullBody;
-    const html = await md2html(md);
-    return { md, html };
+    const { convertedHtml, originalHtml } = await md2html(md);
+    return {
+      md,
+      html: convertedHtml,
+      original: originalHtml,
+    };
   }
   return {
     error: new Error(

--- a/src/modules/ExlMd2Html.js
+++ b/src/modules/ExlMd2Html.js
@@ -63,6 +63,7 @@ async function converter(mdString) {
   createShadeBox(document);
   createCodeBlock(document);
 
+  // leave this at the end
   handleNestedBlocks(document);
 
   return {

--- a/src/modules/ExlMd2Html.js
+++ b/src/modules/ExlMd2Html.js
@@ -8,8 +8,6 @@ import { raw } from 'hast-util-raw';
 import rehypeFormat from 'rehype-format';
 import { toHtml } from 'hast-util-to-html';
 import jsdom from 'jsdom';
-// import prettier from 'prettier/standalone';
-// import prettierPluginHTML from 'prettier/plugins/html';
 import createVideo from './blocks/create-video.js';
 import createBadge from './blocks/create-badge.js';
 import createRelatedArticles from './blocks/create-article.js';
@@ -19,6 +17,7 @@ import createTables from './blocks/create-tables.js';
 // import { createSections } from './utils/dom-utils.js';
 import createShadeBox from './blocks/create-shade-box.js';
 import createCodeBlock from './blocks/create-code-block.js';
+import handleNestedBlocks from './blocks/nested-blocks.js';
 
 async function converter(mdString) {
   const convertedHtml = markdownit({
@@ -64,12 +63,12 @@ async function converter(mdString) {
   createShadeBox(document);
   createCodeBlock(document);
 
-  /* FIXME: Page breaking - docs/authoring-guide-exl/using/markdown/syntax-style-guide
-  return prettier.format(dom.serialize(), {
-    parser: 'html',
-    plugins: [prettierPluginHTML],
-  }); */
-  return dom.serialize();
+  handleNestedBlocks(document);
+
+  return {
+    convertedHtml: dom.serialize(),
+    originalHtml: html,
+  };
 }
 
 export default async function md2html(mdString) {

--- a/src/modules/blocks/create-badge.js
+++ b/src/modules/blocks/create-badge.js
@@ -35,7 +35,7 @@ export default function createBadge(document) {
         cells = [[div1], [div2]];
       }
 
-      const block = toBlock(`Badge ${variant}`, cells, document);
+      const block = toBlock(`badge ${variant}`, cells, document);
       element.parentNode.parentNode.replaceChild(block, element.parentNode);
     } else {
       const div1 = document.createElement('div');
@@ -56,7 +56,7 @@ export default function createBadge(document) {
         cells = [[div1], [div2]];
       }
 
-      const block = toBlock(`Badge (${variant})`, cells, document);
+      const block = toBlock(`badge (${variant})`, cells, document);
       replaceElement(element, block);
     }
   });

--- a/src/modules/blocks/create-code-block.js
+++ b/src/modules/blocks/create-code-block.js
@@ -70,7 +70,7 @@ export default function createCodeBlock(document) {
 
     const cells = [[pre]];
 
-    const block = toBlock(`Code ${blockOptions.join(' ')}`, cells, document);
+    const block = toBlock(`code ${blockOptions.join(' ')}`, cells, document);
     element.parentNode.parentNode.replaceChild(block, element.parentNode);
   });
 }

--- a/src/modules/blocks/nested-blocks.js
+++ b/src/modules/blocks/nested-blocks.js
@@ -1,0 +1,41 @@
+import { blockToTable, replaceElement } from '../utils/dom-utils.js';
+
+/**
+ *
+ * @param {Document} document
+ */
+export default function handleNestedBlocks(document) {
+  // Add container block classes this array
+  const containerBlockClasses = ['shade-box', 'table', 'tabs'];
+
+  // Add content block classes this array
+  const contentBlockClasses = [
+    'code',
+    'note',
+    'related-articles',
+    'Badge',
+    'embed',
+  ];
+
+  containerBlockClasses.forEach((containerBlock) => {
+    // container blocks have the strict structure body > main > div > .${containerBlock}
+    const containers = Array.from(
+      document.querySelectorAll(`body > main > div > .${containerBlock}`),
+    );
+
+    // find nested blocks (converted in previous steps), and convert it to a table
+    containers.forEach((container) => {
+      [...containerBlockClasses, ...contentBlockClasses].forEach(
+        (nestedBlockClass) => {
+          const nestedBlocks = [
+            ...container.getElementsByClassName(nestedBlockClass),
+          ];
+          nestedBlocks.forEach((nestedBlock) => {
+            const table = blockToTable(nestedBlock, document);
+            replaceElement(nestedBlock, table);
+          });
+        },
+      );
+    });
+  });
+}

--- a/src/modules/blocks/nested-blocks.js
+++ b/src/modules/blocks/nested-blocks.js
@@ -1,7 +1,9 @@
 import { blockToTable, replaceElement } from '../utils/dom-utils.js';
 
 /**
- *
+ * retroactively converts any nested blocks into tables.
+ * hlx converter does not handle nested blocks, for good reason. but we do have use-cases where block are nested
+ * For that, this conversion turns only nested blocks into tables, and those tables will be handled at the frontend.
  * @param {Document} document
  */
 export default function handleNestedBlocks(document) {

--- a/src/modules/blocks/nested-blocks.js
+++ b/src/modules/blocks/nested-blocks.js
@@ -8,10 +8,10 @@ import { blockToTable, replaceElement } from '../utils/dom-utils.js';
  */
 export default function handleNestedBlocks(document) {
   // Add container block classes this array
-  const containerBlockClasses = ['shade-box', 'table', 'tabs'];
-
-  // Add content block classes this array
-  const contentBlockClasses = [
+  const blockClasses = [
+    'shade-box',
+    'table',
+    'tabs',
     'code',
     'note',
     'related-articles',
@@ -19,25 +19,19 @@ export default function handleNestedBlocks(document) {
     'embed',
   ];
 
-  containerBlockClasses.forEach((containerBlock) => {
-    // container blocks have the strict structure body > main > div > .${containerBlock}
-    const containers = Array.from(
-      document.querySelectorAll(`body > main > div > .${containerBlock}`),
-    );
+  // top level blocks (container blocks) blocks have the strict structure body > main > div > div
+  const blocks = Array.from(
+    document.querySelectorAll('body > main > div > div'),
+  );
 
-    // find nested blocks (converted in previous steps), and convert it to a table
-    containers.forEach((container) => {
-      [...containerBlockClasses, ...contentBlockClasses].forEach(
-        (nestedBlockClass) => {
-          const nestedBlocks = [
-            ...container.getElementsByClassName(nestedBlockClass),
-          ];
-          nestedBlocks.forEach((nestedBlock) => {
-            const table = blockToTable(nestedBlock, document);
-            replaceElement(nestedBlock, table);
-          });
-        },
-      );
+  // find nested blocks (converted in previous steps), and convert it to a table
+  blocks.forEach((block) => {
+    blockClasses.forEach((nestedBlockClass) => {
+      const nestedBlocks = [...block.getElementsByClassName(nestedBlockClass)];
+      nestedBlocks.forEach((nestedBlock) => {
+        const table = blockToTable(nestedBlock, document);
+        replaceElement(nestedBlock, table);
+      });
     });
   });
 }

--- a/src/modules/utils/dom-utils.js
+++ b/src/modules/utils/dom-utils.js
@@ -43,6 +43,86 @@ export const toBlock = (className, rows, document) => {
 };
 
 /**
+ *
+ * @param {HTMLElement} element
+ * @returns {boolean} true if element is a div
+ */
+export const isDiv = (element) =>
+  element && element.tagName.toLowerCase() === 'div';
+
+/**
+ *
+ * @param {HTMLDivElement} block
+ * @returns
+ */
+export const isValidBlock = (block) => {
+  if (!block) throw new Error(`block is required`);
+  if (!isDiv(block)) throw new Error(`block must be a div`);
+  if (!block.classList.length > 0)
+    throw new Error(`block must have at least one class`);
+
+  // all rows must be divs
+  const rows = Array.from(block.children);
+
+  rows.forEach((row, index) => {
+    if (!isDiv(row)) throw new Error(`Row ${index} is not a div`);
+    const cells = Array.from(row.children);
+    if (!cells.every(isDiv))
+      throw new Error(`At least one cell in row ${index} is not a div`);
+  });
+
+  return true;
+};
+
+/**
+ *
+ * @param {HTMLDivElement} block
+ * @param {Document} document
+ * @returns
+ */
+export const blockToTable = (block, document) => {
+  let valid = false;
+  try {
+    valid = isValidBlock(block);
+  } catch (e) {
+    console.error(e);
+  }
+
+  if (valid) {
+    // create table header, first header row is the block's class names
+    const table = document.createElement('table');
+    const thead = document.createElement('thead');
+    const headerRow = document.createElement('tr');
+    const headerCell = document.createElement('th');
+    headerCell.textContent = block.getAttribute('class');
+    headerRow.appendChild(headerCell);
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    console.log(block.innerHTML);
+    // create table body
+    const tbody = document.createElement('tbody');
+    [...block.children].forEach((row) => {
+      const tr = document.createElement('tr');
+      const cells = Array.from(row.children);
+      cells.forEach((cell) => {
+        const td = document.createElement('td');
+        // console.log(cell.innerHTML)
+        td.append(...Array.from(cell.childNodes));
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+
+    return table;
+  }
+
+  // all else fails
+  return block;
+};
+
+/**
  * Replace element with newElement
  * @param {HTMLElement} element
  * @param {HTMLElement} newElement

--- a/src/modules/utils/dom-utils.js
+++ b/src/modules/utils/dom-utils.js
@@ -29,7 +29,7 @@ const append = (parent, children) => {
  * @returns {HTMLDivElement} the block element (and subtree)
  */
 export const toBlock = (className, rows, document) => {
-  const parent = div(document, className);
+  const parent = div(document, className.toLowerCase());
   rows.forEach((row) => {
     const rowDiv = div(document);
     row.forEach((cell) => {

--- a/src/modules/utils/dom-utils.js
+++ b/src/modules/utils/dom-utils.js
@@ -99,7 +99,6 @@ export const blockToTable = (block, document) => {
     thead.appendChild(headerRow);
     table.appendChild(thead);
 
-    console.log(block.innerHTML);
     // create table body
     const tbody = document.createElement('tbody');
     [...block.children].forEach((row) => {
@@ -107,7 +106,6 @@ export const blockToTable = (block, document) => {
       const cells = Array.from(row.children);
       cells.forEach((cell) => {
         const td = document.createElement('td');
-        // console.log(cell.innerHTML)
         td.append(...Array.from(cell.childNodes));
         tr.appendChild(td);
       });
@@ -148,7 +146,6 @@ const getHeadingLevel = (element) => {
  * @param {Document} document
  */
 export const createSections = (document) => {
-  console.log(`create sections`);
   const main = document.body.querySelector('main');
   if (!main) return;
   const sections = [];


### PR DESCRIPTION
This PR handles converting nested blocks into tables retroactively.

For each block converter, the converter need not worry weather the block is nested or not, conversion is agnostic to that.

After all block conversions are done, this PR looks up all blocks under main, with the specific selector `body > main > div > div` (top level blocks)

Then in each top-level block, it looks up blocks with specific classes (that has been converted already), and converts them to specifically structured tables. Each of these tables would have the block classes as headers, and each row in that block would be a table row.




