### PR TITLE
Use URL article API and use mapping for internal URLs only

### DIFF
--- a/src/modules/ExlMd2Html.js
+++ b/src/modules/ExlMd2Html.js
@@ -24,8 +24,9 @@ import createArticleMetaDataCreatedBy from './blocks/create-article-metadata-cre
 import markdownItToHtml from './MarkdownIt.js';
 import createMiniTOC from './blocks/create-mini-toc.js';
 
-async function converter(mdString, meta) {
-  const convertedHtml = markdownItToHtml(mdString);
+export default async function md2html(mdString, meta) {
+  const amfProcessed = afm(mdString, 'extension');
+  const convertedHtml = markdownItToHtml(amfProcessed);
 
   const main = fromHtml(convertedHtml, { fragment: true });
 
@@ -80,8 +81,4 @@ async function converter(mdString, meta) {
     convertedHtml: dom.serialize(),
     originalHtml: html,
   };
-}
-
-export default async function md2html(mdString, meta) {
-  return converter(afm(mdString, 'extension'), meta);
 }

--- a/src/url-mapping.js
+++ b/src/url-mapping.js
@@ -1,33 +1,5 @@
 export default [
   {
-    path: '/docs/workfront/using/adobe-workfront-api/api-general-information/rich-text-field-api',
-    id: 'rechyRjUfs7xI4oZT',
-  },
-  {
-    path: '/docs/experience-platform/destinations/destination-sdk/functionality/destination-configuration/customer-authentication',
-    id: 'recZmWz9iUegew5Pn',
-  },
-  {
-    path: '/docs/journey-optimizer/using/ajo-home',
-    id: 'rec3NyHcJR7wJO8do',
-  },
-  {
-    path: '/docs/commerce-operations/configuration-guide/setup/initialization',
-    id: 'recslOZIKI2EKwjJl',
-  },
-  {
-    path: '/docs/data-workbench/using/hidden-test-page',
-    id: 'rec3qevEC7zbIeJco',
-  },
-  {
-    path: '/docs/integrations-learn/experience-cloud/solution-categories/content-management',
-    id: 'recrWO51UB125Pd29',
-  },
-  {
-    path: '/docs/analytics-learn/tutorials/analysis-workspace/navigating-workspace-projects/annotations-in-analysis-workspace',
-    id: 'recAjPiXNFnQj3jG3',
-  },
-  {
     path: '/docs/authoring-guide-exl/using/markdown/cheatsheet',
     id: 'recXZZxBo4pkOnx9k',
   },
@@ -35,64 +7,37 @@ export default [
     path: '/docs/authoring-guide-exl/using/markdown/syntax-style-guide',
     id: 'rec9WkO4eYWupFTrM',
   },
-  {
-    path: '/docs/experience-platform/landing/platform-apis/api-authentication',
-    id: 'reckcjRiLD5XYLFri',
-  },
-  {
-    path: '/docs/experience-platform/sources/ui-tutorials/create/cloud-storage/google-pubsub',
-    id: 'recSsOSKBiv9XioJA',
-  },
-  {
-    path: '/docs/journey-optimizer-learn/tutorials/introduction-to-journey-optimizer/mobile-capabilities-for-developers',
-    id: 'recGseE0j7HEteLlx',
-  },
-  {
-    path: '/docs/target-learn/tutorials/activities/create-ab-tests',
-    id: 'recCgLaXS1llwMbvb',
-  },
+
   {
     path: '/docs/authoring-guide-exl/using/authoring/tables',
     id: 'recSamvuJkILYVR1q  ',
   },
   {
-    path: '/docs/experience-manager-cloud-service/content/migration-journey/getting-started-partners',
-    id: 'rec9rN1MgLgR562Vh',
+    path: '/docs/authoring-guide-exl/using/authoring/linking',
+    id: 'recDHkKH0MjzPsrwq',
   },
   {
-    path: '/docs/creative-cloud-enterprise-learn/cce-learning-hub/cceoverview/overview-cce',
-    id: 'recUYHeFeLdTLak8z',
+    path: '/docs/authoring-guide-exl/using/authoring/using-metadata',
+    id: 'reczCFfhqIQlpEejb',
   },
   {
-    path: '/docs/creative-cloud-enterprise-learn/cce-learning-hub/cceoverview/ccerefguides/overview-ref',
-    id: 'rec7ajLazYrkI06nk',
+    path: '/docs/authoring-guide-exl/using/authoring/restructure-new',
+    id: 'recmQ0mtsvAYkwo4W',
   },
   {
-    path: '/docs/creative-cloud-enterprise-learn/cce-learning-hub/videooverview/overview-dva',
-    id: 'recLXJKP3A0JPghmz',
+    path: '/docs/authoring-guide-exl/using/authoring/includes',
+    id: 'rec3GuzJeOONUCEzJ',
   },
   {
-    path: '/docs/integrations-learn/experience-cloud/solution-categories/content-management',
-    id: 'recrWO51UB125Pd29',
+    path: '/docs/authoring-guide-exl/using/authoring/microsites',
+    id: 'recfe17eUvR7lnLCm',
   },
   {
-    path: '/docs/marketo/using/release-notes/previous-releases/2023/release-notes-sep-23',
-    id: 'rec1MHITzwBDe6dsf',
+    path: '/docs/authoring-guide-exl/using/authoring/contextual-help-popovers',
+    id: 'recwo9P3E9EjlToZo',
   },
   {
-    path: '/docs/marketo/using/product-docs/demand-generation/dynamic-chat/automated-chat/stream-designer',
-    id: 'recUQH1McIQ3uqRil',
-  },
-  {
-    path: '/docs/analytics/components/segmentation/seg-containers',
-    id: 'recsIiOJagHPjA6o5',
-  },
-  {
-    path: '/docs/experience-manager-guides-learn/tutorials/user-guide/manage-content/authoring-file-management',
-    id: 'recfxewptHHfJR6xn',
-  },
-  {
-    path: '/docs/blueprints-learn/architecture/customer-journeys/journey-optimizer/journey-optimizer',
-    id: 'recFhzRw6szJBc7Cq',
+    path: '/docs/authoring-guide-exl/using/authoring/courses',
+    id: 'rec6E43FbKY1GDdeb',
   },
 ];


### PR DESCRIPTION
This PR moves away from using url mapping to using the EXL API to lookup docs by path, for example:

Looking up the article for this doc: https://experienceleague.adobe.com/docs/experience-manager-learn/cloud-service/caching/author.html?lang=en
 Can be done with:
 
https://experienceleague.adobe.com/api/articles?URL=https://experienceleague.adobe.com/docs/experience-manager-learn/cloud-service/caching/author.html?lang=en

For internal pages, we will continue to use a url mapping until a more permanent solution is implemented.
