### PR TITLE
Move AEM Configurations to Environment Variables

### DIFF
--- a/.github/workflows/deploy-action.yaml
+++ b/.github/workflows/deploy-action.yaml
@@ -30,3 +30,4 @@ jobs:
           OWNER: ${{ vars.OWNER }}
           REPO: ${{ vars.REPO }}
           BRANCH: ${{ vars.GITHUB_REF_NAME }}
+          AEM_AUTHOR_URL: ${{ vars.AEM_AUTHOR_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 node_modules
 dev.json
+build/.local.env

--- a/README.md
+++ b/README.md
@@ -16,6 +16,36 @@ That will build the action code inside an express app, with [src/express.js](src
 
 The express app listens on port 3030 and handles incoming requests for _.html and _.md files, applying the html transformations.
 
+### Serving AEM Pages Locally
+
+> This simulates an authenticated request, coming from Edge Delivery Services intended to render from AEM.
+
+1. get your local development access token from Cloud Manager Developer Console (see docs below)
+2. Add file `build/.local.env` that should have the contents below (replace `<token>` with your token and `<aem author>` with the author url)
+```
+AEM_AUTHOR_URL=<aem author>
+OWNER=adobe-experience-league
+REPO=exlm
+BRANCH=main
+# get your local development access token from Cloud Manager Developer Console
+ACCESS_TOKEN=<token>
+```
+
+#### Getting an AEM Developer Access Token
+
+> [see cloud manager documentation on Developer Console and access](https://experienceleague.adobe.com/docs/experience-manager-learn/cloud-service/debugging/debugging-aem-as-a-cloud-service/developer-console.html?lang=en)
+
+1. Navigate to Cloud Manager (If you dont have access to Cloud Manager, contact your program Admin)
+2. Find your Program (again, contact your admin for program Name)
+3. Find your environment
+4. Navigate to the Developer Console for that environment
+5. Click on `integration` Tab
+6. Click on `Get Local Development Token`
+
+> Developer tokens are short lived and should only be used for local testing/debugging.
+
+
+
 ## Deployment
 
 The action is built and deployed by a [github workflow](../../.github/workflows/deploy-action.yaml). 
@@ -27,6 +57,19 @@ If you want to test this action on your own runtime application, it is recommend
 ```
 aio app deploy
 ```
+
+### Github Deployment Action
+The action requires the follwoing environment variables/secrets to be set:
+> see github docs for how to add those: https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository
+
+| Name                    | Type   |
+|-------------------------|--------|
+| `AIO_RUNTIME_AUTH`      | secret |
+| `AIO_RUNTIME_NAMESPACE` | secret |
+| `OWNER`                 | var    |
+| `REPO`                  | var    |
+| `AEM_AUTHOR_URL`        | var    |
+
 
 ## Debugging common issues
 

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -12,6 +12,11 @@ application:
             runtime: 'nodejs:18'
             inputs:
               LOG_LEVEL: debug
+              aemAuthorUrl: $AEM_AUTHOR_URL
+              aemOwner: $OWNER
+              aemRepo: $REPO
+              aemBranch: $BRANCH
+
             annotations:
               require-adobe-auth: false # explicitly unauthenticated action
               final: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@adobe/aio-lib-core-logging": "^2.0.1",
         "@babel/eslint-parser": "^7.22.15",
         "adobe-afm-transform": "^1.2.24",
+        "dotenv": "^16.3.1",
         "hast-util-from-html": "^2.0.1",
         "hast-util-raw": "8.0.0",
         "hast-util-to-html": "8.0.4",
@@ -11620,7 +11621,6 @@
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
       "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -32866,8 +32866,7 @@
     "dotenv": {
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "dev": true
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
     "dotenv-expand": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@adobe/aio-lib-core-logging": "^2.0.1",
     "@babel/eslint-parser": "^7.22.15",
     "adobe-afm-transform": "^1.2.24",
+    "dotenv": "^16.3.1",
     "hast-util-from-html": "^2.0.1",
     "hast-util-raw": "8.0.0",
     "hast-util-to-html": "8.0.4",

--- a/src/aem-config.js
+++ b/src/aem-config.js
@@ -1,6 +1,0 @@
-export default {
-  aemEnv: 'https://author-p122525-e1200861.adobeaemcloud.com',
-  owner: 'adobe-experience-league',
-  repo: 'exlm',
-  ref: 'main',
-};

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@
  */
 
 import Logger from '@adobe/aio-lib-core-logging';
-import aemConfig from './aem-config.js';
 import renderDoc from './renderers/render-doc.js';
 import renderFragment from './renderers/render-fragment.js';
 import renderAem from './renderers/render-aem.js';
@@ -23,6 +22,13 @@ const aioLogger = Logger('App');
  * @property {string} __ow_path - path of the request
  * @property {Object} __ow_headers - headers of the request
  * @property {authorization} authorization - authorization header
+ * @property {string} aemAuthorUrl - AEM Author URL
+ * @property {string} aemOwner - AEM Owner
+ * @property {string} aemRepo - AEM Repo
+ * @property {string} aemBranch - AEM Branch
+ */
+
+/**
  *
  * @param {string} path
  * @param {Params} params
@@ -37,13 +43,13 @@ export const render = async function render(path, params) {
     return renderFragment(path);
   }
   // Handle AEM UE Pages by default
-  return renderAem(path, params, aemConfig);
+  return renderAem(path, params);
 };
 
 export const main = async function main(params) {
   aioLogger.info({ params });
   // eslint-disable-next-line camelcase
-  const { __ow_path, __ow_headers } = params;
+  const { __ow_path, __ow_headers, aemAuthorUrl } = params;
   // eslint-disable-next-line camelcase
   const path = __ow_path || '';
   // eslint-disable-next-line camelcase
@@ -53,7 +59,7 @@ export const main = async function main(params) {
     return {
       statusCode: 200,
       headers: {
-        'x-html2md-img-src': aemConfig.aemEnv, // tells franklin services to index images starting with this and use auth with it.
+        'x-html2md-img-src': aemAuthorUrl, // tells franklin services to index images starting with this and use auth with it.
       },
       body: html,
     };

--- a/src/renderers/render-aem.js
+++ b/src/renderers/render-aem.js
@@ -8,11 +8,10 @@ import isBinary from '../modules/utils/media-utils.js';
 /**
  * Renders content from AEM UE pages
  */
-export default async function renderAem(path, params, config) {
-  const { authorization } = params;
-  const { aemEnv, owner, repo, ref } = config;
+export default async function renderAem(path, params) {
+  const { aemAuthorUrl, aemOwner, aemRepo, aemBranch, authorization } = params;
 
-  const aemURL = `${aemEnv}/bin/franklin.delivery/${owner}/${repo}/${ref}${path}?wcmmode=disabled`;
+  const aemURL = `${aemAuthorUrl}/bin/franklin.delivery/${aemOwner}/${aemRepo}/${aemBranch}${path}?wcmmode=disabled`;
   const url = new URL(aemURL);
 
   const fetchHeaders = { 'cache-control': 'no-cache' };
@@ -46,7 +45,7 @@ export default async function renderAem(path, params, config) {
   const elements = document.querySelectorAll('img');
   elements.forEach((el) => {
     const uri = el.getAttribute('src');
-    if (!isAbsoluteURL(uri)) el.src = relativeToAbsolute(uri, aemEnv);
+    if (!isAbsoluteURL(uri)) el.src = relativeToAbsolute(uri, aemAuthorUrl);
   });
   return { html: dom.serialize() };
 }

--- a/src/renderers/render-aem.js
+++ b/src/renderers/render-aem.js
@@ -1,0 +1,52 @@
+import jsdom from 'jsdom';
+import {
+  isAbsoluteURL,
+  relativeToAbsolute,
+} from '../modules/utils/link-utils.js';
+import isBinary from '../modules/utils/media-utils.js';
+
+/**
+ * Renders content from AEM UE pages
+ */
+export default async function renderAem(path, params, config) {
+  const { authorization } = params;
+  const { aemEnv, owner, repo, ref } = config;
+
+  const aemURL = `${aemEnv}/bin/franklin.delivery/${owner}/${repo}/${ref}${path}?wcmmode=disabled`;
+  const url = new URL(aemURL);
+
+  const fetchHeaders = { 'cache-control': 'no-cache' };
+  if (authorization) {
+    fetchHeaders.authorization = authorization;
+  }
+
+  const resp = await fetch(url, { headers: fetchHeaders });
+
+  if (!resp.ok) {
+    return { error: { code: resp.status, message: resp.statusText } };
+  }
+
+  let contentType = resp.headers.get('content-type') || 'text/html';
+  [contentType] = contentType.split(';');
+
+  const respHeaders = {
+    'content-type': contentType,
+  };
+
+  if (isBinary(contentType)) {
+    const data = Buffer.from(await resp.arrayBuffer());
+    return { data, respHeaders };
+  }
+
+  const html = await resp.text();
+
+  // FIXME: Converting images from AEM to absolue path. Revert once product fix in place.
+  const dom = new jsdom.JSDOM(html);
+  const { document } = dom.window;
+  const elements = document.querySelectorAll('img');
+  elements.forEach((el) => {
+    const uri = el.getAttribute('src');
+    if (!isAbsoluteURL(uri)) el.src = relativeToAbsolute(uri, aemEnv);
+  });
+  return { html: dom.serialize() };
+}

--- a/src/renderers/render-doc.js
+++ b/src/renderers/render-doc.js
@@ -1,0 +1,27 @@
+import ExlClient from '../modules/ExlClient.js';
+import md2html from '../modules/ExlMd2Html.js';
+import { removeExtension } from '../modules/utils/path-utils.js';
+
+const exlClient = new ExlClient({
+  domain: 'https://experienceleague.adobe.com',
+});
+/**
+ * handles a markdown doc path
+ */
+export default async function renderDoc(path) {
+  const response = await exlClient.getArticleByPath(removeExtension(path));
+  if (response.data.length > 0) {
+    const md = response.data[0].FullBody;
+    const meta = response.data[0].FullMeta;
+    const data = response.data[0];
+    const { convertedHtml, originalHtml } = await md2html(md, meta, data);
+    return {
+      md,
+      html: convertedHtml,
+      original: originalHtml,
+    };
+  }
+  return {
+    error: new Error(`No Page found for: ${path}`),
+  };
+}

--- a/src/renderers/render-fragment.js
+++ b/src/renderers/render-fragment.js
@@ -1,0 +1,34 @@
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+import { join, dirname } from 'path';
+import { addExtension } from '../modules/utils/path-utils.js';
+
+// need this to work with both esm and commonjs
+let dir;
+try {
+  dir = __dirname; // if commonjs, this will get current directory
+} catch (e) {
+  dir = dirname(fileURLToPath(import.meta.url)); // if esm, this will get current directory
+}
+
+/**
+ * Renders fragment from filesystem at given path
+ */
+export default function renderFragment(path) {
+  if (path) {
+    const fragmentPath = join(dir, '..', addExtension(path, '.html'));
+    // Get header and footer static content from Github
+    if (fs.existsSync(fragmentPath)) {
+      const html = fs.readFileSync(fragmentPath, 'utf-8');
+      return {
+        html,
+      };
+    }
+    return {
+      error: new Error(`Fragment: ${path} not found`),
+    };
+  }
+  return {
+    error: new Error('Tried to render fragment for an empty path'),
+  };
+}


### PR DESCRIPTION
1. Refactor Action code, separate each renderer to their own file
2. Move AEM configurations from a JS file in the repo, to environment variables instead - and update the github action and the local express server and docs for both.