### PR TITLE
Make renderers API generic and pass-through content-type header

### DIFF
--- a/build/express.js
+++ b/build/express.js
@@ -30,6 +30,12 @@ try {
 const app = express();
 const port = 3030;
 
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @returns
+ */
 const handler = async (req, res) => {
   const { path, query } = req;
 
@@ -42,12 +48,16 @@ const handler = async (req, res) => {
     authorization: `Bearer ${ACCESS_TOKEN}`,
   };
 
-  const { html, md, original, error } = await render(path, params);
+  const { body, headers, md, original, error } = await render(path, params);
+
   if (error) {
     res.status(error.code || 503);
     res.send(error.message);
     return;
   }
+  // set headers as they are.
+  Object.entries(headers).forEach(([key, value]) => res.setHeader(key, value));
+
   res.status(200);
   if (path.endsWith('.md')) {
     res.setHeader('Content-Type', 'text/plain');
@@ -55,7 +65,7 @@ const handler = async (req, res) => {
   } else if (path.endsWith('.original')) {
     res.send(original);
   } else {
-    res.send(html);
+    res.send(body);
   }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -59,19 +59,20 @@ export const render = async function render(path, params) {
 export const main = async function main(params) {
   aioLogger.info({ params });
   // eslint-disable-next-line camelcase
-  const { __ow_path, __ow_headers, aemAuthorUrl } = params;
+  const { __ow_path, __ow_headers } = params;
   // eslint-disable-next-line camelcase
   const path = __ow_path || '';
   // eslint-disable-next-line camelcase
   const authorization = __ow_headers?.authorization || '';
-  const { html, error } = await render(path, { ...params, authorization });
+  const { body, headers, error } = await render(path, {
+    ...params,
+    authorization,
+  });
   if (!error) {
     return {
       statusCode: 200,
-      headers: {
-        'x-html2md-img-src': aemAuthorUrl, // tells franklin services to index images starting with this and use auth with it.
-      },
-      body: html,
+      headers,
+      body,
     };
   }
 

--- a/src/modules/utils/media-utils.js
+++ b/src/modules/utils/media-utils.js
@@ -82,7 +82,17 @@ const mediaTypes = {
   'application/zip': true,
 };
 
-export default function isBinary(contentType) {
+/**
+ * @param {string} contentType
+ */
+export function isBinary(contentType) {
+  if (!contentType) return false;
+
+  // eslint-disable-next-line no-param-reassign
+  contentType = contentType.includes(';')
+    ? contentType.split(';')[0]
+    : contentType;
+
   if (contentType.startsWith('text/') || contentType.startsWith('message/')) {
     return false;
   }
@@ -94,4 +104,11 @@ export default function isBinary(contentType) {
     return true;
   }
   return mediaTypes[contentType];
+}
+
+/**
+ * @param {string} contentType
+ */
+export function isHTML(contentType) {
+  return contentType?.toLocaleLowerCase()?.startsWith('text/html');
 }

--- a/src/renderers/render-doc.js
+++ b/src/renderers/render-doc.js
@@ -16,8 +16,11 @@ export default async function renderDoc(path) {
     const data = response.data[0];
     const { convertedHtml, originalHtml } = await md2html(md, meta, data);
     return {
+      body: convertedHtml,
+      headers: {
+        'Content-Type': 'text/html',
+      },
       md,
-      html: convertedHtml,
       original: originalHtml,
     };
   }

--- a/src/renderers/render-fragment.js
+++ b/src/renderers/render-fragment.js
@@ -12,9 +12,12 @@ export default function renderFragment(path, parentFolderPath) {
   if (path) {
     // Get header and footer static content from Github
     if (fs.existsSync(fragmentPath)) {
-      const html = fs.readFileSync(fragmentPath, 'utf-8');
+      const body = fs.readFileSync(fragmentPath, 'utf-8');
       return {
-        html,
+        body,
+        headers: {
+          'Content-Type': 'text/html',
+        },
       };
     }
     return {


### PR DESCRIPTION
Renderers are now required to return `body` and `headers` instead of `html`
This is to handle binary and non-html responses like JSON or text

Also return proper `Content-Type` headers and pass-through the `Content-Type` for AEM rendering