### PR TITLE
breadcrumbs converter

### DIFF
--- a/src/modules/ExlMd2Html.js
+++ b/src/modules/ExlMd2Html.js
@@ -27,6 +27,7 @@ import createMiniTOC from './blocks/create-mini-toc.js';
 import createImgBlock from './blocks/create-img-block.js';
 import createAccordion from './blocks/create-accordion.js';
 import createTOC from './blocks/create-toc.js';
+import createBreadcrumbs from './blocks/create-breadcrumbs.js';
 
 const doAmf = (md) => {
   // AMF has a bug where it doesn't handle tripple-backticks correctly.
@@ -93,6 +94,7 @@ export default async function md2html(mdString, meta, data) {
   createTOC(document);
   createImgBlock(document);
   createAccordion(document);
+  createBreadcrumbs(document);
   // leave this at the end
   handleNestedBlocks(document);
 

--- a/src/modules/blocks/create-breadcrumbs.js
+++ b/src/modules/blocks/create-breadcrumbs.js
@@ -1,0 +1,31 @@
+import { toBlock } from '../utils/dom-utils.js';
+
+// ideally second argument meta should be passed once API response is working fine
+export default function createBreadcrumbs(document) {
+  // Breadcrumbs metadata extraction
+  const mockMetaBreadcrumbs =
+    '{"breadcrumbs" : [{"title": "Documentation","url": "/docs/?lang=en"},{"title":"Target","url": "/docs/target.html?lang=en"},{"title":"Target Guide","url":"/docs/target/using/target-home.html?lang=en"},{"title":"How","url":""}]}';
+  // TODO relapce mockMetaBreadcrumbs with meta once the API response is in correct format
+  // const fullMetadata = yaml.load(meta);
+  const headerElement = document.querySelector('h1');
+
+  const mockBreadcrumbs = JSON.parse(mockMetaBreadcrumbs);
+  // TODO replace mockMetaBreadcrumbs with fullMetadata once line 8 gets uncommented
+  const { breadcrumbs } = mockBreadcrumbs;
+  const metaDivTag = document.createElement('div');
+  // Article Metadata breadcrumbs
+  if (breadcrumbs) {
+    breadcrumbs.forEach((breadcrumb) => {
+      const anchorTag = document.createElement('a');
+      const { url } = breadcrumb;
+      if (url) {
+        anchorTag.setAttribute('href', url);
+        anchorTag.textContent = breadcrumb.title;
+        metaDivTag.append(anchorTag);
+      }
+    });
+  }
+  const cells = [[metaDivTag]];
+  const block = toBlock('breadcrumbs', cells, document);
+  headerElement.parentNode.insertBefore(block, headerElement);
+}


### PR DESCRIPTION
The PR has been raised based on the comment by Ahamed in https://jira.corp.adobe.com/browse/EXLM-280 i.e at the moment the breadcrumb converter has been written based on the mock json metadata which is expected from page API response. 
We need to revisit the breadcrumbs once the correct API response is available.