### PR TITLE
Update deploy-action.yaml

### DIFF
--- a/.github/workflows/deploy-action.yaml
+++ b/.github/workflows/deploy-action.yaml
@@ -56,10 +56,10 @@ jobs:
           AEM_AUTHOR_URL: ${{ vars.AEM_AUTHOR_URL }}
           OWNER: ${{ vars.OWNER }}
           REPO: ${{ vars.REPO }}
-          BRANCH: ${{ github.ref_name }}
+          BRANCH: ${{ vars.BRANCH }}
       - name: Publish Fragments
         run: npm run publish-fragments
         env:
           OWNER: ${{ vars.OWNER }}
           REPO: ${{ vars.REPO }}
-          BRANCH: ${{ github.ref_name }}
+          BRANCH: ${{ vars.BRANCH }}


### PR DESCRIPTION
UE publishing blocked as the GH Action picking the current branch name for fetching the content from AEM. Created a new repo variable called BRANCH and updated the action to pass on the variable to converter runtime.