### PR TITLE
Fixed anchor links

### DIFF
--- a/src/converter/modules/utils/link-utils.js
+++ b/src/converter/modules/utils/link-utils.js
@@ -61,7 +61,11 @@ export function rewriteDocsPath(docsPath) {
   const lang = url.searchParams.get('lang') || 'en'; // en is default
   url.searchParams.delete('lang');
   let pathname = `${lang.toLowerCase()}${url.pathname}`;
-  pathname = removeExtension(pathname); // new URLs are extensionless
+  // In case of Urls like - /docs/target-learn/tutorials/administration/strategy/1.1-implementation-strategy-sys-governance
+  if (pathname.includes('.html') || pathname.includes('.md')) {
+    pathname = removeExtension(pathname); // new URLs are extensionless
+  }
+  console.log(pathname);
   url.pathname = pathname;
   // return full path without origin
   return url.toString().replace(TEMP_BASE, '');

--- a/src/converter/modules/utils/link-utils.js
+++ b/src/converter/modules/utils/link-utils.js
@@ -65,7 +65,6 @@ export function rewriteDocsPath(docsPath) {
   if (pathname.includes('.html') || pathname.includes('.md')) {
     pathname = removeExtension(pathname); // new URLs are extensionless
   }
-  console.log(pathname);
   url.pathname = pathname;
   // return full path without origin
   return url.toString().replace(TEMP_BASE, '');


### PR DESCRIPTION
In case of URLs like
/docs/target-learn/tutorials/administration/strategy/1.1-implementation-strategy-sys-governance.html?lang=en, /docs/target-learn/tutorials/implementation/2.1-intro-to-target-implementation.html?lang=en ,
/docs/target-learn/tutorials/integrations/3.2-target-analytics.html?lang=en
strings after . are getting removed.
https://main--exlm--adobe-experience-league.hlx.live/en/docs/target 

Added condition if extension is .html or .md, then calling the removeExtension() method.