### PR TITLE
404 for invalid solution landing pages

### DIFF
--- a/src/converter/modules/ExlClient.js
+++ b/src/converter/modules/ExlClient.js
@@ -124,8 +124,9 @@ export default class ExlClient {
   }
 
   async getLandingPageByFileName(landingName, lang = 'en') {
+    const langForAPI = getMatchLanguage(lang) || lang;
     if (!landingName) throw new Error('landingName is required');
-    const landingPages = await this.getLandingPages(lang);
+    const landingPages = await this.getLandingPages(langForAPI);
     const landingPage = landingPages.find(
       (landing) =>
         removeExtension(landing.File) === removeExtension(landingName),

--- a/src/converter/renderers/render-landing.js
+++ b/src/converter/renderers/render-landing.js
@@ -24,24 +24,29 @@ export default async function renderLanding(path) {
     lang,
   );
 
-  let md = landingPage?.Markdown;
-  const meta = landingPage?.FullMeta;
-  const potentialDuplicateAnchors = Object.values(LANDING_IDS);
-  md = dedupeAnchors(md, potentialDuplicateAnchors);
+  if (landingPage !== undefined) {
+    let md = landingPage?.Markdown;
+    const meta = landingPage?.FullMeta;
+    const potentialDuplicateAnchors = Object.values(LANDING_IDS);
+    md = dedupeAnchors(md, potentialDuplicateAnchors);
 
-  const { convertedHtml, originalHtml } = await md2html(
-    md,
-    meta,
-    {},
-    pageType,
-    lang,
-  );
+    const { convertedHtml, originalHtml } = await md2html(
+      md,
+      meta,
+      {},
+      pageType,
+      lang,
+    );
+    return {
+      body: convertedHtml,
+      headers: {
+        'Content-Type': 'text/html',
+      },
+      md,
+      original: originalHtml,
+    };
+  }
   return {
-    body: convertedHtml,
-    headers: {
-      'Content-Type': 'text/html',
-    },
-    md,
-    original: originalHtml,
+    error: new Error(`No Page found for: ${path}`),
   };
 }


### PR DESCRIPTION
1. Updated correct lang (case-sensitive) for Landing API as the existing API call wasn't returning translated content for pt-br, zh-hans and zh-hant.
2. Added 404 for landing pages that do not exist in Landing API response.
   https://experienceleague.adobe.com/api/landing-pages?lang=en&page_size=100