### PR TITLE
Corrected links for all languages

### DIFF
--- a/src/converter/modules/utils/language-utils.js
+++ b/src/converter/modules/utils/language-utils.js
@@ -13,34 +13,9 @@ const LANGUAGES = [
   'ko',
 ];
 
-const LANGUAGESMAP = {
-  'de-de': 'de',
-  en: 'en',
-  'es-es': 'es',
-  'fr-fr': 'fr',
-  'it-it': 'it',
-  'nl-nl': 'nl',
-  'pt-br': 'pt-br',
-  'sv-se': 'sv',
-  'zh-hans': 'zh-hans',
-  'zh-hant': 'zh-hant',
-  'ja-jp': 'ja',
-  'ko-kr': 'ko',
-};
-
 export const getMatchLanguage = (lang) => {
   if (lang) {
     return LANGUAGES.find((l) => l.toLowerCase() === lang.toLowerCase());
-  }
-  return lang;
-};
-
-export const getMatchLanguageCode = (lang) => {
-  if (lang) {
-    const lowercaseLang = lang.toLowerCase();
-    if (LANGUAGESMAP[lowercaseLang]) {
-      return LANGUAGESMAP[lowercaseLang];
-    }
   }
   return lang;
 };

--- a/src/converter/modules/utils/language-utils.js
+++ b/src/converter/modules/utils/language-utils.js
@@ -13,9 +13,34 @@ const LANGUAGES = [
   'ko',
 ];
 
+const LANGUAGESMAP = {
+  'de-de': 'de',
+  en: 'en',
+  'es-es': 'es',
+  'fr-fr': 'fr',
+  'it-it': 'it',
+  'nl-nl': 'nl',
+  'pt-br': 'pt-br',
+  'sv-se': 'sv',
+  'zh-hans': 'zh-hans',
+  'zh-hant': 'zh-hant',
+  'ja-jp': 'ja',
+  'ko-kr': 'ko',
+};
+
 export const getMatchLanguage = (lang) => {
   if (lang) {
     return LANGUAGES.find((l) => l.toLowerCase() === lang.toLowerCase());
+  }
+  return lang;
+};
+
+export const getMatchLanguageCode = (lang) => {
+  if (lang) {
+    const lowercaseLang = lang.toLowerCase();
+    if (LANGUAGESMAP[lowercaseLang]) {
+      return LANGUAGESMAP[lowercaseLang];
+    }
   }
   return lang;
 };

--- a/src/converter/modules/utils/link-utils.js
+++ b/src/converter/modules/utils/link-utils.js
@@ -1,5 +1,5 @@
 import { removeExtension } from './path-utils.js';
-import { getMatchLanguageCode } from './language-utils.js';
+import { getMatchLanguage } from './language-utils.js';
 
 /**
  * Checks if a URL is an absolute URL.
@@ -61,7 +61,7 @@ export function rewriteDocsPath(docsPath) {
   const url = new URL(docsPath, TEMP_BASE);
   const lang = url.searchParams.get('lang') || 'en'; // en is default
   url.searchParams.delete('lang');
-  const rewriteLang = getMatchLanguageCode(lang);
+  const rewriteLang = getMatchLanguage(lang) || lang.split('-')[0];
   let pathname = `${rewriteLang.toLowerCase()}${url.pathname}`;
   const extRegex = /\.[0-9a-z]+$/i; // Regular expression to match file extensions
 

--- a/src/converter/modules/utils/link-utils.js
+++ b/src/converter/modules/utils/link-utils.js
@@ -1,4 +1,5 @@
 import { removeExtension } from './path-utils.js';
+import { getMatchLanguageCode } from './language-utils.js';
 
 /**
  * Checks if a URL is an absolute URL.
@@ -60,7 +61,8 @@ export function rewriteDocsPath(docsPath) {
   const url = new URL(docsPath, TEMP_BASE);
   const lang = url.searchParams.get('lang') || 'en'; // en is default
   url.searchParams.delete('lang');
-  let pathname = `${lang.toLowerCase()}${url.pathname}`;
+  const rewriteLang = getMatchLanguageCode(lang);
+  let pathname = `${rewriteLang.toLowerCase()}${url.pathname}`;
   const extRegex = /\.[0-9a-z]+$/i; // Regular expression to match file extensions
 
   if (extRegex.test(pathname)) {


### PR DESCRIPTION
The links are not rendered correctly for non-english pages. E.g. https://main--exlm--adobe-experience-league.hlx.page/ko/docs/analytics
Its pointing to /ko-kr/ instead of /ko/
<img width="683" alt="image" src="https://github.com/adobe-experience-league/exlm-converter/assets/145125444/41f0e85e-6224-4925-af37-06da2e8011e1">
