### PR TITLE
Return /docs Article regardless of path case sensitivity 

### DIFF
--- a/src/converter/modules/ExlClient.js
+++ b/src/converter/modules/ExlClient.js
@@ -105,7 +105,8 @@ export default class ExlClient {
     let url = new URL(finalPath, this.domain);
     url.searchParams.set('lang', langForApi);
     url = encodeURIComponent(url.toString());
-    const apiPath = `api/articles?URL=${url}&lang=${langForApi}`;
+    url = url.toLowerCase(); // use lowercase when using `Search%20URL` query param
+    const apiPath = `api/articles?Search%20URL=${url}&lang=${langForApi}`;
     const response = await this.doFetch(apiPath);
 
     if (response.error) {


### PR DESCRIPTION
This PR ensures that the converter resolves articles even if the article path has upper case chars; by using the new `Search URL` param of the EXL API.