### PR TITLE
Add anchors as icon suffixes

### DIFF
--- a/src/converter/modules/ExlMd2Html.js
+++ b/src/converter/modules/ExlMd2Html.js
@@ -31,6 +31,7 @@ import createBreadcrumbs from './blocks/create-breadcrumbs.js';
 import createDocActions from './blocks/create-doc-actions.js';
 import createCloudSolutions from './blocks/create-cloud-solutions.js';
 import createLandingLists from './blocks/create-landing-lists.js';
+import { updateAnchors } from './utils/update-anchors.js';
 
 const doAmf = (md) => {
   // AMF has a bug where it doesn't handle tripple-backticks correctly.
@@ -79,6 +80,7 @@ export default async function md2html(mdString, meta, data, pageType, reqLang) {
   const { document } = dom.window;
   createMetaData(document, meta, data, pageType);
   handleUrls(document, reqLang);
+  updateAnchors(document);
   if (pageType === DOCPAGETYPE.DOC_LANDING) {
     createCloudSolutions(document);
     handleExternalUrl(document);

--- a/src/converter/modules/utils/update-anchors.js
+++ b/src/converter/modules/utils/update-anchors.js
@@ -1,0 +1,15 @@
+/**
+ * the helix html2md pipeline diregards any "id" attributes on headers (and other els I believe)
+ * so we need a way for these ids to survive the html2md pipeline. These IDs are used as anchors.
+ * Here, we suffix the heading text with an icon whose name is anchor-<heading id>.
+ * On the FE, we will use this icon name to restore the "id" on the heading.
+ * @param {Document} document
+ */
+export const updateAnchors = (document) => {
+  document.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((headingEl) => {
+    if (headingEl.id) {
+      const anchor = document.createTextNode(`:anchor-${headingEl.id}:`);
+      headingEl.appendChild(anchor);
+    }
+  });
+};


### PR DESCRIPTION
the helix html2md pipeline diregards any "id" attributes on headers (and other els I believe). so we need a way for these ids to survive the html2md pipeline. These IDs are used as anchors. This PR solves that issue. see: `src/converter/modules/utils/update-anchors.js`