### PR TITLE
Updated logic based on page type

### DIFF
--- a/src/converter/modules/utils/link-utils.js
+++ b/src/converter/modules/utils/link-utils.js
@@ -108,15 +108,17 @@ export default function handleUrls(document, reqLang, pageType) {
     if (pathToRewrite === null) return;
 
     if (isAbsoluteURL(pathToRewrite)) {
-      // If the absolute URL starts with https://experienceleague.adobe.com/# or https://experienceleague.adobe.com/?, return as is
-      if (
-        pathToRewrite.startsWith(`${baseUrl}/?`) ||
-        pathToRewrite.startsWith(`${baseUrl}/#`)
-      )
-        return;
-
       // make url relative if it is absolute AND has the same passed baseUrl (Prod EXL)
       let newPath = absoluteToRelative(pathToRewrite, baseUrl);
+
+      if (
+        pageType === DOCPAGETYPE.DOC_LANDING &&
+        (newPath.startsWith(`/?`) || newPath.startsWith(`/#`))
+      ) {
+        // Update newPath to "/home" and append the original query string or hash
+        newPath = newPath.replace(/^\/?/, '/home');
+      }
+
       // rewrite docs path to fix language path
       newPath = rewriteDocsPath(newPath);
       el.href = newPath;


### PR DESCRIPTION
For Docs landing page, updated links for courses and support.
If courses link starts with /#courses, updating it to **/home#courses**
If support link starts with /?support-solution=General&support-tab=home#support, updating to **/home?support-solution=General&support-tab=home#support**