### PR TITLE
EXLM-1197 Docs Landing page

### DIFF
--- a/src/converter/renderers/render-landing.js
+++ b/src/converter/renderers/render-landing.js
@@ -14,7 +14,7 @@ export default async function renderLanding(path) {
 
   let landingName = 'home';
   let pageType = DOCPAGETYPE.DOC_LANDING;
-  if (lang && solution) {
+  if (lang && solution && solution !== 'home') {
     landingName = solution;
     pageType = DOCPAGETYPE.SOLUTION_LANDING;
   }


### PR DESCRIPTION
Currently "/en/docs/home" is rendered as a solution landing page.
https://eds-stage.experienceleague.adobe.com/en/docs/home

Updated logic to render solution name "home" as Docs landing page.