### PR TITLE
EXLM-1432 No-index no-follow for fragments

### DIFF
--- a/src/converter/renderers/render-fragment.js
+++ b/src/converter/renderers/render-fragment.js
@@ -54,7 +54,9 @@ export default async function renderFragment(path, parentFolderPath) {
         body = `
         <!doctype html>
         <html>
-          <head></head>
+          <head>
+            <meta name="ROBOTS" content="NOINDEX, NOFOLLOW, NOARCHIVE, NOSNIPPET">
+          </head>
           <body>
             <header></header>
             <main>


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/EXLM-1432
Added noindex & nofollow rules to all EDS fragments so these pages are not indexed.

![image](https://github.com/adobe-experience-league/exlm-converter/assets/145125444/40ad78d6-13bb-4db2-87e1-95e359e1a36f)
