### PR TITLE
Automatically create create (and publish) fragments when page has over 100 images

### DIFF
--- a/app.config.yaml
+++ b/app.config.yaml
@@ -47,3 +47,14 @@ application:
             annotations:
               require-adobe-auth: false # explicitly unauthenticated action
               final: true
+          publish:
+            function: dist/publish # this is a folder that is built by the pre-app-build hook. needs to be a folder to serve static fragment files
+            web: 'no'
+            runtime: 'nodejs:18'
+            inputs:
+              LOG_LEVEL: debug
+              owner: $OWNER
+              repo: $REPO
+              branch: $BRANCH
+            annotations:
+              final: true

--- a/build/build-helpers.js
+++ b/build/build-helpers.js
@@ -30,7 +30,7 @@ export const createEsbuildOptions = (overrides) => ({
   platform: 'node',
   format: 'cjs', // needs to be cjs to support  __dirname and __filename for fragment serving
   target: 'node18', // this is the version in app.config.yaml
-  external: ['canvas', 'bufferutil', 'utf-8-validate'],
+  external: ['canvas', 'bufferutil', 'utf-8-validate', 'openwhisk'],
   plugins: [jsdomPatch],
   logLevel: 'info',
   keepNames: true, // needed because of: https://github.com/node-fetch/node-fetch/issues/784#issuecomment-1014768204

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "markdown-it-sub": "^1.0.0",
         "markdown-it-sup": "^1.0.0",
         "mdast-util-to-hast": "12.3.0",
+        "openwhisk": "^3.21.8",
         "path-to-regexp": "^6.2.1",
         "rehype-format": "4.0.1",
         "unist-util-visit": "5.0.0"
@@ -10230,7 +10231,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
       "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "dev": true,
       "dependencies": {
         "retry": "0.13.1"
       }
@@ -18603,16 +18603,15 @@
       }
     },
     "node_modules/openwhisk": {
-      "version": "3.21.7",
-      "resolved": "https://registry.npmjs.org/openwhisk/-/openwhisk-3.21.7.tgz",
-      "integrity": "sha512-mxMdZlk+U8k+EPc2/4sdXs2JgxzKtpqeKicJG/zgeocZeSpDFhte07U/2h1rVPq8S5VTMsN/jU+Ua65/QTzAlg==",
-      "dev": true,
+      "version": "3.21.8",
+      "resolved": "https://registry.npmjs.org/openwhisk/-/openwhisk-3.21.8.tgz",
+      "integrity": "sha512-GoD4wytw7KSNSwZ4f6/iQcLPJK8cW0FRyhuaQkRbsGL6BCV9tigQ9zoQdJRkZUKilm29cLyGIAF5cn3pFn73LQ==",
       "dependencies": {
         "async-retry": "^1.3.3",
-        "needle": "^2.4.0"
+        "needle": "^3.2.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/openwhisk-fqn": {
@@ -18620,6 +18619,32 @@
       "resolved": "https://registry.npmjs.org/openwhisk-fqn/-/openwhisk-fqn-0.0.2.tgz",
       "integrity": "sha512-xHjI8boduclL5X1Wx5pe1vjF4Eo+coF0nf4dO2mLpYwmep0dYwAlc7n3NkW5ygGZOhlcEJUjPXxFpxLRa9W/iA==",
       "dev": true
+    },
+    "node_modules/openwhisk/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openwhisk/node_modules/needle": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
+      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.3",
@@ -20193,7 +20218,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -32220,7 +32244,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
       "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "dev": true,
       "requires": {
         "retry": "0.13.1"
       }
@@ -38407,13 +38430,31 @@
       }
     },
     "openwhisk": {
-      "version": "3.21.7",
-      "resolved": "https://registry.npmjs.org/openwhisk/-/openwhisk-3.21.7.tgz",
-      "integrity": "sha512-mxMdZlk+U8k+EPc2/4sdXs2JgxzKtpqeKicJG/zgeocZeSpDFhte07U/2h1rVPq8S5VTMsN/jU+Ua65/QTzAlg==",
-      "dev": true,
+      "version": "3.21.8",
+      "resolved": "https://registry.npmjs.org/openwhisk/-/openwhisk-3.21.8.tgz",
+      "integrity": "sha512-GoD4wytw7KSNSwZ4f6/iQcLPJK8cW0FRyhuaQkRbsGL6BCV9tigQ9zoQdJRkZUKilm29cLyGIAF5cn3pFn73LQ==",
       "requires": {
         "async-retry": "^1.3.3",
-        "needle": "^2.4.0"
+        "needle": "^3.2.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "needle": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
+          "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+          "requires": {
+            "iconv-lite": "^0.6.3",
+            "sax": "^1.2.4"
+          }
+        }
       }
     },
     "openwhisk-fqn": {
@@ -39602,8 +39643,7 @@
     "retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",
     "mdast-util-to-hast": "12.3.0",
+    "openwhisk": "^3.21.8",
     "path-to-regexp": "^6.2.1",
     "rehype-format": "4.0.1",
     "unist-util-visit": "5.0.0"

--- a/src/common/utils/publish-util.js
+++ b/src/common/utils/publish-util.js
@@ -1,0 +1,71 @@
+/**
+ * Publish a path to Helix Pages via Admin API
+ * @typedef {object} PublishParams
+ * @property {string} path - path to publish
+ * @property {'preview' | 'live'} mode - either 'preview' or 'live'
+ * @property {string} owner - GitHub owner
+ * @property {string} repo - GitHub repo
+ * @property {string} branch - GitHub branch
+ * @param {PublishParams} param
+ * @returns
+ */
+
+export default async function publish({
+  path,
+  mode = 'live',
+  owner,
+  repo,
+  branch,
+  apiKey,
+}) {
+  const url = `https://admin.hlx.page/${mode}/${owner}/${repo}/${branch}/${path}`;
+  console.log(
+    `[FETCH] [POST]: ${url} (API_KEY: ${String(apiKey).substring(0, 5)}...)`,
+  );
+  const headers = {};
+  if (apiKey) {
+    headers.authorization = `token ${apiKey}`;
+  }
+  return fetch(url, { method: 'POST', headers });
+}
+
+/**
+ * publishes a path to Edge Delivery Services via Admin API
+ * @param {PublishParams} params
+ */
+const publishPath = async (params) => {
+  const { mode, path } = params;
+  try {
+    const response = await publish(params);
+    if (response.ok) {
+      const jsonResponse = await response.json();
+      console.log(`[Published] [${mode}]: ${jsonResponse[mode].url}`);
+      return jsonResponse;
+    }
+    console.error(
+      `[Error] [${mode}] [Response Code: ${response.status}]: ${path}`,
+    );
+    console.error(`Reponse text: \n${await response.text()}`);
+  } catch (err) {
+    console.error(err);
+  }
+  return undefined;
+};
+
+/**
+ * @param {PublishParams} params
+ */
+export const previewThenPublish = async (params) => {
+  const previewResponseJson = await publishPath({
+    ...params,
+    mode: 'preview',
+  });
+  const publishResponseJson = await publishPath({
+    ...params,
+    mode: 'live',
+  });
+  return {
+    previewResponseJson,
+    publishResponseJson,
+  };
+};

--- a/src/converter/modules/ExlMd2Html.js
+++ b/src/converter/modules/ExlMd2Html.js
@@ -41,6 +41,7 @@ import { createRecommendationMoreHelp } from './blocks/create-recommendation-mor
 import createDocsCards from './blocks/create-docs-cards.js';
 import { createMetaData } from './utils/metadata-util.js';
 import { createDefaultExlClient } from './ExlClient.js';
+import handleTooManyImages from './blocks/too-many-images.js';
 
 const doAmf = (md) => {
   // AMF has a bug where it doesn't handle tripple-backticks correctly.
@@ -61,6 +62,7 @@ export default async function md2html({
   data,
   pageType,
   reqLang,
+  path,
 }) {
   const amfProcessed = doAmf(mdString, 'extension');
   const convertedHtml = markdownItToHtml(amfProcessed);
@@ -76,8 +78,8 @@ export default async function md2html({
       h('header', []),
       h('main', [
         h('div', content.hast), // Base Content - Must be first child for proper rendering
-        h('div', []), // Left Rail Block - TOC - Must be second-last section for proper rendering
-        h('div', []), // Right Rail Block - mini TOC - Must be last section for proper rendering
+        h('div', { class: 'section' }, []), // Left Rail Block - TOC - Must be second-last section for proper rendering
+        h('div', { class: 'section' }, []), // Right Rail Block - mini TOC - Must be last section for proper rendering
       ]),
       h('footer', []),
     ]),
@@ -137,6 +139,8 @@ export default async function md2html({
     createRecommendationMoreHelp(document);
     // leave this at the end
     handleNestedBlocks(document);
+    // leave this at the end - UGP-10894 Handle Too Many Images
+    handleTooManyImages(document, path);
     // leave this at the end - EXLM 1442 1510 Splitting into multiple Sections
     createSections(document);
   }

--- a/src/converter/modules/blocks/too-many-images.js
+++ b/src/converter/modules/blocks/too-many-images.js
@@ -1,3 +1,4 @@
+import openwhisk from 'openwhisk';
 import {
   createNewSectionForBlock,
   htmlFragmentToDoc,
@@ -88,7 +89,7 @@ class Fragments {
         el.remove();
       });
 
-      const fragmentPath = `/fragments${this.pagePath}/fragment-${this.currentFragmentIndex}.html`;
+      const fragmentPath = `/fragments${this.pagePath}/fragment-${this.currentFragmentIndex}`;
       a.href = fragmentPath;
       a.innerHTML = fragmentPath;
 
@@ -97,7 +98,16 @@ class Fragments {
         filePath: fragmentPath,
         arrayBuffer: new TextEncoder().encode(fragmentDoc),
       });
-      // this.currentElement.insertAdjacentElement('afterend', block.innerHTML);
+      const ow = openwhisk();
+      const result = await ow.actions.invoke({
+        name: 'main/publish', // the name of the action to invoke
+        blocking: false, // this is the flag that instructs to execute the worker asynchronous
+        result: true,
+        params: {
+          path: fragmentPath,
+        },
+      });
+      console.log(`result`, { result });
     }
   }
 }

--- a/src/converter/modules/blocks/too-many-images.js
+++ b/src/converter/modules/blocks/too-many-images.js
@@ -1,0 +1,126 @@
+import {
+  createNewSectionForBlock,
+  htmlFragmentToDoc,
+  toBlock,
+} from '../utils/dom-utils.js';
+import { writeFile } from '../utils/file-utils.js';
+
+const MAX_IMAGE_COUNT = 100;
+
+const getImages = (element) => {
+  if (element.tagName === 'IMG') {
+    return [element];
+  }
+  return [...element.querySelectorAll('img')];
+};
+
+class Fragments {
+  /**
+   * @param {String} pagePath
+   */
+  constructor(pagePath) {
+    /** @type {HTMLElement[][]} */
+    this.fragments = [];
+    /** @type {number} */
+    this.currentFragmentIndex = 0;
+    this.currentElement = undefined;
+    /** @type {String} */
+    this.pagePath = pagePath;
+  }
+
+  /**
+   * @param {HTMLElement} element
+   */
+  add(element) {
+    if (!this.canAdd(element)) {
+      this.next();
+    }
+    if (this.fragments[this.currentFragmentIndex] === undefined)
+      this.fragments[this.currentFragmentIndex] = [];
+    this.fragments[this.currentFragmentIndex].push(element);
+    this.currentElement = element;
+  }
+
+  /**
+   * @param {HTMLElement} element
+   * @returns
+   */
+  canAdd(element) {
+    if (this.fragments[this.currentFragmentIndex] === undefined) return true;
+    const fragmentImageCount = this.fragments[this.currentFragmentIndex].reduce(
+      (acc, el) => acc + getImages(el).length,
+      0,
+    );
+    return fragmentImageCount + getImages(element).length <= MAX_IMAGE_COUNT;
+  }
+
+  next() {
+    this.writeCurrentFragment();
+    this.currentFragmentIndex += 1;
+  }
+
+  /**
+   * @typedef WriteOptions
+   * @property {HTMLElement} element
+   * @property {HTMLElement} parent
+   */
+  /**
+   *
+   * @param {WriteOptions} options
+   * @returns
+   */
+  async writeCurrentFragment() {
+    const fragment = this.fragments[this.currentFragmentIndex];
+    // TODO write the fragment to files
+    if (this.currentElement) {
+      const document = this.currentElement.ownerDocument;
+      const section = document.createElement('div');
+      section.classList.add('section');
+      const a = document.createElement('a');
+      const block = toBlock('fragment', [[a]], document);
+      this.currentElement.after(block);
+
+      const newSection = createNewSectionForBlock(document, block);
+      newSection.appendChild(block);
+
+      fragment.forEach((el) => {
+        section.append(el.cloneNode(true));
+        el.remove();
+      });
+
+      const fragmentPath = `/fragments${this.pagePath}/fragment-${this.currentFragmentIndex}.html`;
+      a.href = fragmentPath;
+      a.innerHTML = fragmentPath;
+
+      const fragmentDoc = htmlFragmentToDoc(section.outerHTML);
+      await writeFile({
+        filePath: fragmentPath,
+        arrayBuffer: new TextEncoder().encode(fragmentDoc),
+      });
+      // this.currentElement.insertAdjacentElement('afterend', block.innerHTML);
+    }
+  }
+}
+
+/**
+ * @param {Document} document
+ */
+export default function handleTooManyImages(document, path) {
+  const images = document.querySelectorAll('img');
+  if (images.length <= MAX_IMAGE_COUNT) return;
+  const main = document.querySelector('main');
+  const sections = Array.from(main.children).slice(0, -2);
+  let currentImageCount = 0;
+
+  const fragments = new Fragments(path);
+
+  sections.forEach((section) => {
+    [...section.children].forEach((child) => {
+      currentImageCount += getImages(child).length;
+      if (currentImageCount > MAX_IMAGE_COUNT) {
+        fragments.add(child);
+      }
+    });
+    fragments.next();
+  });
+}

--- a/src/converter/modules/utils/dom-utils.js
+++ b/src/converter/modules/utils/dom-utils.js
@@ -392,3 +392,20 @@ export function setMetadata(document, name, content) {
     });
   }
 }
+
+export function htmlFragmentToDoc(mainHTMLContentString) {
+  return `
+        <!doctype html>
+        <html>
+          <head>
+            <meta name="robots" content="noindex, nofollow, noarchive, nosnippet">
+          </head>
+          <body>
+            <header></header>
+            <main>
+            ${mainHTMLContentString}
+            </main>
+            <footer></footer>
+          </body>
+        </html>`;
+}

--- a/src/converter/modules/utils/file-utils.js
+++ b/src/converter/modules/utils/file-utils.js
@@ -1,5 +1,8 @@
+import Logger from '@adobe/aio-lib-core-logging';
 import Files from '@adobe/aio-lib-files';
 import LocalFiles from './local-files.js';
+
+export const aioLogger = Logger('file-utils');
 
 const PRESIGNURL_EXPIRY = 900;
 
@@ -24,11 +27,13 @@ export const writeFileAndGetPresignedURL = async ({
 };
 
 export const writeFile = async ({ filePath, arrayBuffer }) => {
+  console.log(`Writing file to ${filePath}`);
   const filesSdk = await getFilesSdk();
   return filesSdk.write(filePath, Buffer.from(arrayBuffer));
 };
 
 export const readFile = async (filePath) => {
+  console.log(`Reading file from ${filePath}`);
   const filesSdk = await getFilesSdk();
   return filesSdk.read(filePath);
 };

--- a/src/converter/modules/utils/file-utils.js
+++ b/src/converter/modules/utils/file-utils.js
@@ -1,0 +1,34 @@
+import Files from '@adobe/aio-lib-files';
+import LocalFiles from './local-files.js';
+
+const PRESIGNURL_EXPIRY = 900;
+
+const getFilesSdk = async () => {
+  if (process.env.NODE_ENV === 'development') {
+    return LocalFiles.init();
+  }
+  return Files.init();
+};
+
+export const writeFileAndGetPresignedURL = async ({
+  filePath,
+  arrayBuffer,
+}) => {
+  const filesSdk = await getFilesSdk();
+
+  await filesSdk.write(filePath, Buffer.from(arrayBuffer));
+  return filesSdk.generatePresignURL(filePath, {
+    expiryInSeconds: PRESIGNURL_EXPIRY,
+    permissions: 'r',
+  });
+};
+
+export const writeFile = async ({ filePath, arrayBuffer }) => {
+  const filesSdk = await getFilesSdk();
+  return filesSdk.write(filePath, Buffer.from(arrayBuffer));
+};
+
+export const readFile = async (filePath) => {
+  const filesSdk = await getFilesSdk();
+  return filesSdk.read(filePath);
+};

--- a/src/converter/modules/utils/local-files.js
+++ b/src/converter/modules/utils/local-files.js
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export default class LocalFiles {
+  constructor() {
+    this.tmpDir = os.tmpdir();
+  }
+
+  static async init() {
+    return new LocalFiles();
+  }
+
+  /**
+   * @param {string} relativePath
+   */
+  getTempPath(relativePath) {
+    return path.join(this.tmpDir, relativePath);
+  }
+
+  /**
+   * @param {string} absolutePath
+   */
+  getRelativePath(absolutePath) {
+    return path.relative(this.tmpDir, absolutePath);
+  }
+
+  async write(filePath, buffer) {
+    const writePath = this.getTempPath(filePath);
+    fs.mkdirSync(path.dirname(writePath), { recursive: true });
+    fs.writeFileSync(writePath, buffer);
+  }
+
+  /**
+   * @param {*} filePath
+   * @param {*} options
+   * @returns
+   */
+  async generatePresignURL(filePath, options) {
+    return this.filesSdk.generatePresignURL(
+      this.getTempPath(filePath),
+      options,
+    );
+  }
+
+  async read(filePath) {
+    return fs.readFileSync(this.getTempPath(filePath));
+  }
+}

--- a/src/converter/modules/utils/prettier-utils.js
+++ b/src/converter/modules/utils/prettier-utils.js
@@ -1,6 +1,10 @@
 import * as prettier from 'prettier/standalone';
 import htmlPlugin from 'prettier/plugins/html';
 
+/**
+ * @param {string} html
+ * @returns
+ */
 export async function formatHtml(html) {
   return prettier.format(html, {
     parser: 'html',

--- a/src/converter/renderers/render-aem-asset.js
+++ b/src/converter/renderers/render-aem-asset.js
@@ -1,7 +1,5 @@
-import Files from '@adobe/aio-lib-files';
 import { AioCoreSDKError } from '@adobe/aio-lib-core-errors';
-
-const PRESIGNURL_EXPIRY = 600;
+import { writeFileAndGetPresignedURL } from '../modules/utils/file-utils.js';
 
 /**
  * @param {ArrayBuffer} arrayBuffer
@@ -12,16 +10,6 @@ function toBase64String(arrayBuffer) {
 }
 
 const OneMB = 1024 * 1024 - 1024; // -1024 for good measure :)
-
-const writeFileAndGetPresignedURL = async (filePath, arrayBuffer) => {
-  const filesSdk = await Files.init();
-
-  await filesSdk.write(filePath, Buffer.from(arrayBuffer));
-  return filesSdk.generatePresignURL(filePath, {
-    expiryInSeconds: PRESIGNURL_EXPIRY,
-    permissions: 'r',
-  });
-};
 
 /**
  *
@@ -45,10 +33,10 @@ export default async function renderAemAsset(path, response) {
     // Adobe runtime actions have a response limit of 1MB.
     // so if the asset is larger, write to AIO Files and return a redirect to the presigned URL
     try {
-      const location = await writeFileAndGetPresignedURL(
-        path,
-        await response.arrayBuffer(),
-      );
+      const location = await writeFileAndGetPresignedURL({
+        filePath: path,
+        arrayBuffer: await response.arrayBuffer(),
+      });
       assetHeaders = {
         location,
       };

--- a/src/converter/renderers/render-doc.js
+++ b/src/converter/renderers/render-doc.js
@@ -37,6 +37,7 @@ export default async function renderDoc(path) {
       data: article,
       pageType: DOCPAGETYPE.DOC_ARTICLE,
       reqLang: lang,
+      path,
     });
     return {
       body: convertedHtml,

--- a/src/converter/renderers/render-fragment.js
+++ b/src/converter/renderers/render-fragment.js
@@ -60,7 +60,8 @@ async function getStaticFragment(path, parentFolderPath) {
 }
 
 async function getDynamicFragment(path) {
-  return readFile(path);
+  const buffer = await readFile(path);
+  return buffer.toString();
 }
 
 /**

--- a/src/converter/renderers/render-fragment.js
+++ b/src/converter/renderers/render-fragment.js
@@ -5,6 +5,8 @@ import yaml from 'js-yaml';
 import { addExtension } from '../modules/utils/path-utils.js';
 import ejsUtils from './utils/ejs-utils.js';
 import { formatHtml } from '../modules/utils/prettier-utils.js';
+import { htmlFragmentToDoc } from '../modules/utils/dom-utils.js';
+import { readFile } from '../modules/utils/file-utils.js';
 
 /**
  * Parse all YAML files in the given directory and return an object where each entry is the yaml file name and the value is the parsed yaml
@@ -30,8 +32,9 @@ function getOptionsInDirectory(directory) {
  * Renders fragment from filesystem at given path
  * @param {string} path - path to fragment from 'src'
  * @param {string} parentFolderPath - path to parent folder of `fragments`
+ * @returns {Promise<string>}
  */
-export default async function renderFragment(path, parentFolderPath) {
+async function getStaticFragment(path, parentFolderPath) {
   const fragmentPath = join(
     parentFolderPath,
     'static',
@@ -42,45 +45,51 @@ export default async function renderFragment(path, parentFolderPath) {
     if (fs.existsSync(fragmentPath)) {
       const folder = dirname(fragmentPath);
 
-      let body;
-      try {
-        const ejsData = {
-          ...getOptionsInDirectory(folder), // make all yaml files in the folder available in the ejs template
-          ...ejsUtils, // this makes exported functions in ejs-utils.js available in the ejs template
-        };
-
-        // see: https://ejs.co/#docs
-        body = ejs.render(fs.readFileSync(fragmentPath, 'utf-8'), ejsData);
-        body = `
-        <!doctype html>
-        <html>
-          <head>
-            <meta name="ROBOTS" content="NOINDEX, NOFOLLOW, NOARCHIVE, NOSNIPPET">
-          </head>
-          <body>
-            <header></header>
-            <main>
-            ${body}
-            </main>
-            <footer></footer>
-          </body>
-        </html>`;
-        body = await formatHtml(body);
-      } catch (error) {
-        console.error(error);
-      }
-      return {
-        body,
-        headers: {
-          'Content-Type': 'text/html',
-        },
+      const ejsData = {
+        ...getOptionsInDirectory(folder), // make all yaml files in the folder available in the ejs template
+        ...ejsUtils, // this makes exported functions in ejs-utils.js available in the ejs template
       };
+
+      // see: https://ejs.co/#docs
+      let body = ejs.render(fs.readFileSync(fragmentPath, 'utf-8'), ejsData);
+      body = htmlFragmentToDoc(body);
+      return formatHtml(body);
     }
+  }
+  return undefined;
+}
+
+async function getDynamicFragment(path) {
+  return readFile(path);
+}
+
+/**
+ * Renders fragment from filesystem at given path
+ * @param {string} path - path to fragment from 'src'
+ * @param {string} parentFolderPath - path to parent folder of `fragments`
+ */
+export default async function renderFragment(path, parentFolderPath) {
+  let body;
+  try {
+    body = await getStaticFragment(path, parentFolderPath);
+  } catch (error) {
+    return { error };
+  }
+
+  if (!body) {
+    body = await getDynamicFragment(path);
+  }
+
+  if (!body) {
     return {
-      error: new Error(`Fragment: ${fragmentPath} not found`),
+      error: new Error(`Fragment: ${path} not found`),
     };
   }
+
   return {
-    error: new Error('Tried to render fragment for an empty path'),
+    body,
+    headers: {
+      'Content-Type': 'text/html',
+    },
   };
 }

--- a/src/publish/index.js
+++ b/src/publish/index.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { previewThenPublish } from '../common/utils/publish-util.js';
+
+export const main = async function main(params) {
+  console.log('Publish Params', JSON.stringify(params, null, 2));
+  await previewThenPublish(params);
+  return {
+    statusCode: 200,
+    body: {
+      payload: 'Published!',
+    },
+  };
+};


### PR DESCRIPTION
see: https://www.aem.live/docs/limits#byom-content-source-limits
The max number of unique images for a page is 100 image.
To get around this, this PR creates a new fragment whose content is everything after the 100th image, while maintaining content within sections.

This is NOT an encouragement to build pages with more than 100 images. But rather an exception for pages that currently exist and have 100 image in them.

Internally, there is validation to tell authors to avoid creating pages with large number of images.
