### PR TITLE
serve AEM responses that are larger than 1MB

### DIFF
--- a/build/express.js
+++ b/build/express.js
@@ -84,7 +84,7 @@ const converterHandler = async (req, res) => {
   }
   // set headers as they are.
   Object.entries(headers).forEach(([key, value]) => res.setHeader(key, value));
-  res.status(200);
+  res.status(statusCode || 200);
   if (path.endsWith('.md')) {
     res.setHeader('Content-Type', 'text/plain');
     res.send(md);

--- a/src/converter/modules/utils/local-files.js
+++ b/src/converter/modules/utils/local-files.js
@@ -26,9 +26,11 @@ export default class LocalFiles {
   }
 
   async write(filePath, buffer) {
+    console.log(`Writing temp file for path ${filePath}`);
     const writePath = this.getTempPath(filePath);
     fs.mkdirSync(path.dirname(writePath), { recursive: true });
     fs.writeFileSync(writePath, buffer);
+    console.log(`File written to ${writePath}`);
   }
 
   /**
@@ -36,11 +38,10 @@ export default class LocalFiles {
    * @param {*} options
    * @returns
    */
-  async generatePresignURL(filePath, options) {
-    return this.filesSdk.generatePresignURL(
-      this.getTempPath(filePath),
-      options,
-    );
+  async generatePresignURL(filePath, options = {}) {
+    const presignedUrl = this.getTempPath(filePath, options);
+    console.log(`Generating presign URL: ${presignedUrl}`);
+    return `file://${presignedUrl}`;
   }
 
   async read(filePath) {

--- a/src/converter/renderers/render-aem.js
+++ b/src/converter/renderers/render-aem.js
@@ -1,5 +1,6 @@
 import jsdom from 'jsdom';
 import Logger from '@adobe/aio-lib-core-logging';
+import { AioCoreSDKError } from '@adobe/aio-lib-core-errors';
 import { isBinary, isHTML } from '../modules/utils/media-utils.js';
 import renderAemAsset from './render-aem-asset.js';
 import {
@@ -13,8 +14,21 @@ import {
   decodeCQMetadata,
 } from './utils/aem-page-meta-utils.js';
 import { getMetadata, setMetadata } from '../modules/utils/dom-utils.js';
+import { writeFileAndGetPresignedURL } from '../modules/utils/file-utils.js';
 
 export const aioLogger = Logger('render-aem');
+
+const byteSize = (str) => new Blob([str]).size;
+const isLessThanOneMB = (str) => byteSize(str) < 1024 * 1024 - 1024; // -1024 for good measure :)
+
+function string2ArrayBuffer(str) {
+  const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  const bufView = new Uint16Array(buf);
+  for (let i = 0, strLen = str.length; i < strLen; i += 1) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
 
 /**
  * Transforms page metadata
@@ -174,6 +188,28 @@ export default async function renderAem(path, params) {
     headers = { ...headers, 'x-html2md-img-src': aemAuthorUrl };
   } else {
     body = await resp.text();
+  }
+
+  // handle AEM response larger than 1MB, for example redirects json
+  if (!isLessThanOneMB(body)) {
+    try {
+      const location = await writeFileAndGetPresignedURL({
+        filePath: path,
+        arrayBuffer: string2ArrayBuffer(body),
+      });
+      body = '';
+      headers = { ...headers, location };
+      statusCode = 302;
+    } catch (e) {
+      if (e instanceof AioCoreSDKError) {
+        body = `Error while serving this path: ${path}. See error logs.`;
+        headers = { 'Content-Type': 'text/plain' };
+        statusCode = 500;
+        console.error(e);
+      } else {
+        throw e;
+      }
+    }
   }
 
   // passthrough the same content type from AEM.


### PR DESCRIPTION
Responses from AEM, like redirects.json might be larger than 1mb.
1mb is the limit for Adobe IO action payload.
this PR writes the AEM response to AIO files, then returns a redirect to the presigned URL of that file.