### PR TITLE
EXLM-1895: allow duplicate lists-release ids.

### DIFF
--- a/src/converter/renderers/utils/landing-utils.js
+++ b/src/converter/renderers/utils/landing-utils.js
@@ -2,6 +2,7 @@ export const LANDING_IDS = {
   LISTS_DOCUMENTATION: 'lists-documentation',
   TILES_TUTORIALS: 'tiles-tutorials',
   LISTS_RESOURCES: 'lists-resources',
+  LISTS_RELEASE: 'lists-release',
 };
 
 export const dedupeAnchors = (mdString, anchorNames) => {


### PR DESCRIPTION
ExL was trying to publish /en/docs/marketo-engage landing page but was failing. Turns out the last change introduced a duplicate lists-release anchor. They corrected the doc for now but Matt request that we address the issue, unless of course, it was designed to prevent duplicate this specific lists-release id.

