### PR TITLE
Hotfix: UGP-11928: fix header anchor not rendered as an icon

### DIFF
--- a/src/converter/modules/utils/update-anchors.js
+++ b/src/converter/modules/utils/update-anchors.js
@@ -23,7 +23,7 @@ export const updateAnchors = (document) => {
     // check if id matches -1 AKA - followed by any number of digits
     if (headingEl.id) {
       if (!isMarkdownItGeneratedId(headingEl.id)) {
-        headingEl.appendChild(document.createTextNode(` :headding-anchor:`));
+        headingEl.appendChild(document.createTextNode(` :headding-anchor: `));
         headingEl.appendChild(document.createTextNode(headingEl.id));
       }
     }


### PR DESCRIPTION
this is due to: adobe/helix-html-pipeline@76f37b0#diff-5d793c559c53235e431b1b6be412b7cb136add07bc5095f0aa7ec8036f96f878R16

this same change is also in Dev/stage but needed to be in prod immediately.