### PR TITLE
UGP-Task-Batch Minor updates and localization issues.

### DIFF
--- a/src/converter/static/fragments/de/footer/footer.html
+++ b/src/converter/static/fragments/de/footer/footer.html
@@ -300,7 +300,7 @@
     <div>
       <div>
         <p>
-          Copyright © 2024 Adobe. All Rights Reserved. /
+          Copyright © 2025 Adobe. All Rights Reserved. /
           <a href="https://www.adobe.com/go/marketingcloud_privacy"
             >Datenschutz</a
           >

--- a/src/converter/static/fragments/de/footer/footer.html
+++ b/src/converter/static/fragments/de/footer/footer.html
@@ -48,7 +48,7 @@
             >
           </li>
           <li>
-            <a href="https://helpx.adobe.com/lt/acrobat/using/whats-new.html"
+            <a href="https://helpx.adobe.com/de/acrobat/using/whats-new.html"
               >Document Cloud-Versionshinweise</a
             >
           </li>
@@ -261,11 +261,6 @@
               >Integrität</a
             >
           </li>
-          <li>
-            <a href="https://www.adobe.com/covid-19-response.html"
-              >COVID-19 Responses</a
-            >
-          </li>
         </ul>
       </div>
     </div>
@@ -315,7 +310,7 @@
           >
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie preferences</a>
+          <a href="#onetrust" title="Cookie preferences">Cookie-Einstellungen</a>
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >Meine persönlichen Informationen nicht verkaufen</a

--- a/src/converter/static/fragments/de/footer/footer.html
+++ b/src/converter/static/fragments/de/footer/footer.html
@@ -310,7 +310,9 @@
           >
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie-Einstellungen</a>
+          <a href="#onetrust" title="Cookie preferences"
+            >Cookie-Einstellungen</a
+          >
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >Meine persönlichen Informationen nicht verkaufen</a

--- a/src/converter/static/fragments/en/footer/footer.html
+++ b/src/converter/static/fragments/en/footer/footer.html
@@ -305,7 +305,7 @@
     <div>
       <div>
         <p>
-          Copyright © 2024 Adobe. All Rights Reserved. /
+          Copyright © 2025 Adobe. All Rights Reserved. /
           <a href="https://www.adobe.com/go/marketingcloud_privacy">Privacy</a>
           /
           <a href="https://www.adobe.com/legal/terms.html">Terms of Use</a>

--- a/src/converter/static/fragments/en/footer/footer.html
+++ b/src/converter/static/fragments/en/footer/footer.html
@@ -48,7 +48,7 @@
             >
           </li>
           <li>
-            <a href="https://helpx.adobe.com/lt/acrobat/using/whats-new.html"
+            <a href="https://helpx.adobe.com/en/acrobat/using/whats-new.html"
               >Document Cloud release notes</a
             >
           </li>
@@ -166,11 +166,11 @@
       <div>
         <ul>
           <li>
-            <a href="/home#support">Experience Cloud support</a>
+            <a href="/home#support">Experience Cloud Support</a>
           </li>
           <li>
             <a href="https://helpx.adobe.com/support/document-cloud.html"
-              >Document Cloud support</a
+              >Document Cloud Support</a
             >
           </li>
           <li>
@@ -189,7 +189,7 @@
       <div>
         <ul>
           <li><a href="https://www.adobe.io/">Adobe I/O</a></li>
-          <li><a href="https://status.adobe.com/">Adobe status</a></li>
+          <li><a href="https://status.adobe.com/">Adobe Status</a></li>
         </ul>
       </div>
     </div>

--- a/src/converter/static/fragments/es/footer/footer.html
+++ b/src/converter/static/fragments/es/footer/footer.html
@@ -314,7 +314,9 @@
           >
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Preferencias de cookies</a>
+          <a href="#onetrust" title="Cookie preferences"
+            >Preferencias de cookies</a
+          >
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >No vender mi información personal</a

--- a/src/converter/static/fragments/es/footer/footer.html
+++ b/src/converter/static/fragments/es/footer/footer.html
@@ -50,7 +50,7 @@
             >
           </li>
           <li>
-            <a href="https://helpx.adobe.com/lt/acrobat/using/whats-new.html"
+            <a href="https://helpx.adobe.com/es/acrobat/using/whats-new.html"
               >Notas de la versión del Document Cloud</a
             >
           </li>
@@ -168,11 +168,11 @@
       <div>
         <ul>
           <li>
-            <a href="/home?lang=es#support">soporte de Experience Cloud</a>
+            <a href="/home?lang=es#support">Soporte de Experience Cloud</a>
           </li>
           <li>
             <a href="https://helpx.adobe.com/support/document-cloud.html"
-              >soporte de Document Cloud</a
+              >Soporte de Document Cloud</a
             >
           </li>
           <li>
@@ -265,11 +265,6 @@
               >Integridad</a
             >
           </li>
-          <li>
-            <a href="https://www.adobe.com/covid-19-response.html"
-              >COVID-19 Responses</a
-            >
-          </li>
         </ul>
       </div>
     </div>
@@ -319,7 +314,7 @@
           >
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie preferences</a>
+          <a href="#onetrust" title="Cookie preferences">Preferencias de cookies</a>
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >No vender mi información personal</a

--- a/src/converter/static/fragments/es/footer/footer.html
+++ b/src/converter/static/fragments/es/footer/footer.html
@@ -304,7 +304,7 @@
     <div>
       <div>
         <p>
-          Copyright © 2024 Adobe. All Rights Reserved. /
+          Copyright © 2025 Adobe. All Rights Reserved. /
           <a href="https://www.adobe.com/go/marketingcloud_privacy"
             >Privacidad</a
           >

--- a/src/converter/static/fragments/es/header/header.yaml
+++ b/src/converter/static/fragments/es/header/header.yaml
@@ -55,10 +55,10 @@ nav:
           - title: Listas de reproducción
             subtitle: Colecciones de vídeos elaboradas por expertos
             url: '/es/playlists'
-          - title: Tutorials
+          - title: Tutoriales
             subtitle: Vídeos y procedimientos específicos de la solución
             url: /es/docs/home-tutorials
-          - title: Perspectives
+          - title: Perspectivas
             subtitle: Perspectivas procesables de clientes de Experience Cloud y expertos de Adobe
             url: /es/perspectives
           - title: Certificación

--- a/src/converter/static/fragments/fr/footer/footer.html
+++ b/src/converter/static/fragments/fr/footer/footer.html
@@ -312,7 +312,9 @@
           >
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Préférences de cookies</a>
+          <a href="#onetrust" title="Cookie preferences"
+            >Préférences de cookies</a
+          >
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >Ne pas vendre mes données personnelles</a

--- a/src/converter/static/fragments/fr/footer/footer.html
+++ b/src/converter/static/fragments/fr/footer/footer.html
@@ -302,7 +302,7 @@
     <div>
       <div>
         <p>
-          Copyright © 2024 Adobe. All Rights Reserved. /
+          Copyright © 2025 Adobe. All Rights Reserved. /
           <a href="https://www.adobe.com/go/marketingcloud_privacy"
             >Confidentialité</a
           >

--- a/src/converter/static/fragments/fr/footer/footer.html
+++ b/src/converter/static/fragments/fr/footer/footer.html
@@ -50,7 +50,7 @@
             >
           </li>
           <li>
-            <a href="https://helpx.adobe.com/lt/acrobat/using/whats-new.html"
+            <a href="https://helpx.adobe.com/fr/acrobat/using/whats-new.html"
               >Notes de mise à jour de Document Cloud</a
             >
           </li>
@@ -263,11 +263,6 @@
               >Intégrité</a
             >
           </li>
-          <li>
-            <a href="https://www.adobe.com/covid-19-response.html"
-              >COVID-19 Responses</a
-            >
-          </li>
         </ul>
       </div>
     </div>
@@ -317,7 +312,7 @@
           >
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie preferences</a>
+          <a href="#onetrust" title="Cookie preferences">Préférences de cookies</a>
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >Ne pas vendre mes données personnelles</a

--- a/src/converter/static/fragments/it/footer/footer.html
+++ b/src/converter/static/fragments/it/footer/footer.html
@@ -48,7 +48,7 @@
             >
           </li>
           <li>
-            <a href="https://helpx.adobe.com/lt/acrobat/using/whats-new.html"
+            <a href="https://helpx.adobe.com/it/acrobat/using/whats-new.html"
               >Note sulla versione di Document Cloud</a
             >
           </li>
@@ -264,11 +264,6 @@
               >Integrità</a
             >
           </li>
-          <li>
-            <a href="https://www.adobe.com/covid-19-response.html"
-              >COVID-19 Responses</a
-            >
-          </li>
         </ul>
       </div>
     </div>
@@ -314,7 +309,7 @@
           <a href="https://www.adobe.com/legal/terms.html">Condizioni d’uso</a>
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie preferences</a>
+          <a href="#onetrust" title="Cookie preferences">Preferenze cookie</a>
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >Non vendere le mie informazioni personali</a

--- a/src/converter/static/fragments/it/footer/footer.html
+++ b/src/converter/static/fragments/it/footer/footer.html
@@ -303,7 +303,7 @@
     <div>
       <div>
         <p>
-          Copyright © 2024 Adobe. All Rights Reserved. /
+          Copyright © 2025 Adobe. All Rights Reserved. /
           <a href="https://www.adobe.com/go/marketingcloud_privacy">Privacy</a>
           /
           <a href="https://www.adobe.com/legal/terms.html">Condizioni d’uso</a>

--- a/src/converter/static/fragments/ja/footer/footer.html
+++ b/src/converter/static/fragments/ja/footer/footer.html
@@ -50,7 +50,7 @@
             >
           </li>
           <li>
-            <a href="https://helpx.adobe.com/lt/acrobat/using/whats-new.html"
+            <a href="https://helpx.adobe.com/en/acrobat/using/whats-new.html"
               >Document Cloud リリースノート</a
             >
           </li>
@@ -267,11 +267,6 @@
               >企業倫理</a
             >
           </li>
-          <li>
-            <a href="https://www.adobe.com/covid-19-response.html"
-              >COVID-19 Responses</a
-            >
-          </li>
         </ul>
       </div>
     </div>
@@ -319,7 +314,7 @@
           <a href="https://www.adobe.com/legal/terms.html">利用条件</a>
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie preferences</a>
+          <a href="#onetrust" title="Cookie preferences">クッキーの設定</a>
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >個人情報の譲渡・販売不可</a

--- a/src/converter/static/fragments/ja/footer/footer.html
+++ b/src/converter/static/fragments/ja/footer/footer.html
@@ -306,7 +306,7 @@
     <div>
       <div>
         <p>
-          Copyright © 2024 Adobe. All Rights Reserved. /
+          Copyright © 2025 Adobe. All Rights Reserved. /
           <a href="https://www.adobe.com/go/marketingcloud_privacy"
             >プライバシー</a
           >

--- a/src/converter/static/fragments/ko/footer/footer.html
+++ b/src/converter/static/fragments/ko/footer/footer.html
@@ -298,7 +298,7 @@
     <div>
       <div>
         <p>
-          Copyright © 2024 Adobe. All Rights Reserved. /
+          Copyright © 2025 Adobe. All Rights Reserved. /
           <a href="https://www.adobe.com/go/marketingcloud_privacy"
             >개인 정보</a
           >

--- a/src/converter/static/fragments/ko/footer/footer.html
+++ b/src/converter/static/fragments/ko/footer/footer.html
@@ -48,7 +48,7 @@
             >
           </li>
           <li>
-            <a href="https://helpx.adobe.com/lt/acrobat/using/whats-new.html"
+            <a href="https://helpx.adobe.com/en/acrobat/using/whats-new.html"
               >Document Cloud 릴리스 노트</a
             >
           </li>
@@ -259,11 +259,6 @@
               >무결성</a
             >
           </li>
-          <li>
-            <a href="https://www.adobe.com/covid-19-response.html"
-              >COVID-19 Responses</a
-            >
-          </li>
         </ul>
       </div>
     </div>
@@ -311,7 +306,7 @@
           <a href="https://www.adobe.com/legal/terms.html">사용 약관</a>
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie preferences</a>
+          <a href="#onetrust" title="Cookie preferences">쿠키 설정</a>
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >내 개인 정보 판매 안 함</a

--- a/src/converter/static/fragments/nl/footer/footer.html
+++ b/src/converter/static/fragments/nl/footer/footer.html
@@ -304,7 +304,7 @@
     <div>
       <div>
         <p>
-          Copyright © 2024 Adobe. All Rights Reserved. /
+          Copyright © 2025 Adobe. All Rights Reserved. /
           <a href="https://www.adobe.com/go/marketingcloud_privacy">Privacy</a>
           /
           <a href="https://www.adobe.com/legal/terms.html"

--- a/src/converter/static/fragments/nl/footer/footer.html
+++ b/src/converter/static/fragments/nl/footer/footer.html
@@ -50,7 +50,7 @@
             >
           </li>
           <li>
-            <a href="https://helpx.adobe.com/lt/acrobat/using/whats-new.html"
+            <a href="https://helpx.adobe.com/nl/acrobat/using/whats-new.html"
               >Opmerkingen bij de release van Document Cloud</a
             >
           </li>
@@ -193,7 +193,7 @@
       <div>
         <ul>
           <li><a href="https://www.adobe.io/">Adobe I/O</a></li>
-          <li><a href="https://status.adobe.com/">Adobe-status</a></li>
+          <li><a href="https://status.adobe.com/">Adobe-Status</a></li>
         </ul>
       </div>
     </div>
@@ -265,11 +265,6 @@
               >Integriteit</a
             >
           </li>
-          <li>
-            <a href="https://www.adobe.com/covid-19-response.html"
-              >COVID-19 Responses</a
-            >
-          </li>
         </ul>
       </div>
     </div>
@@ -317,7 +312,7 @@
           >
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie preferences</a>
+          <a href="#onetrust" title="Cookie preferences">Cookie-voorkeuren</a>
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >Verkoop mijn persoonlijke informatie niet</a

--- a/src/converter/static/fragments/pt-br/footer/footer.html
+++ b/src/converter/static/fragments/pt-br/footer/footer.html
@@ -52,7 +52,7 @@
             >
           </li>
           <li>
-            <a href="https://helpx.adobe.com/lt/acrobat/using/whats-new.html"
+            <a href="https://helpx.adobe.com/en/acrobat/using/whats-new.html"
               >notas de versão do Document Cloud</a
             >
           </li>
@@ -195,7 +195,7 @@
       <div>
         <ul>
           <li><a href="https://www.adobe.io/">Adobe I/O</a></li>
-          <li><a href="https://status.adobe.com/">status do Adobe</a></li>
+          <li><a href="https://status.adobe.com/">Status do Adobe</a></li>
         </ul>
       </div>
     </div>
@@ -271,11 +271,6 @@
               >Integridade</a
             >
           </li>
-          <li>
-            <a href="https://www.adobe.com/covid-19-response.html"
-              >COVID-19 Responses</a
-            >
-          </li>
         </ul>
       </div>
     </div>
@@ -323,7 +318,7 @@
           <a href="https://www.adobe.com/legal/terms.html">Termos de uso</a>
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie preferences</a>
+          <a href="#onetrust" title="Cookie preferences">Preferências de cookies</a>
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >Não vender minhas informações pessoais</a

--- a/src/converter/static/fragments/pt-br/footer/footer.html
+++ b/src/converter/static/fragments/pt-br/footer/footer.html
@@ -310,7 +310,7 @@
     <div>
       <div>
         <p>
-          Copyright © 2024 Adobe. All Rights Reserved. /
+          Copyright © 2025 Adobe. All Rights Reserved. /
           <a href="https://www.adobe.com/go/marketingcloud_privacy"
             >Privacidade</a
           >

--- a/src/converter/static/fragments/pt-br/footer/footer.html
+++ b/src/converter/static/fragments/pt-br/footer/footer.html
@@ -318,7 +318,9 @@
           <a href="https://www.adobe.com/legal/terms.html">Termos de uso</a>
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Preferências de cookies</a>
+          <a href="#onetrust" title="Cookie preferences"
+            >Preferências de cookies</a
+          >
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >Não vender minhas informações pessoais</a

--- a/src/converter/static/fragments/sv/footer/footer.html
+++ b/src/converter/static/fragments/sv/footer/footer.html
@@ -300,7 +300,7 @@
     <div>
       <div>
         <p>
-          Copyright © 2024 Adobe. All Rights Reserved. /
+          Copyright © 2025 Adobe. All Rights Reserved. /
           <a href="https://www.adobe.com/go/marketingcloud_privacy"
             >Sekretess</a
           >

--- a/src/converter/static/fragments/sv/footer/footer.html
+++ b/src/converter/static/fragments/sv/footer/footer.html
@@ -310,7 +310,9 @@
           >
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie-inställningar</a>
+          <a href="#onetrust" title="Cookie preferences"
+            >Cookie-inställningar</a
+          >
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >Sälj inte mina personuppgifter</a

--- a/src/converter/static/fragments/sv/footer/footer.html
+++ b/src/converter/static/fragments/sv/footer/footer.html
@@ -48,7 +48,7 @@
             >
           </li>
           <li>
-            <a href="https://helpx.adobe.com/lt/acrobat/using/whats-new.html"
+            <a href="https://helpx.adobe.com/en/acrobat/using/whats-new.html"
               >Versionsinformation för Document Cloud</a
             >
           </li>
@@ -166,7 +166,7 @@
       <div>
         <ul>
           <li>
-            <a href="/home?lang=sv#support">Experience Cloud-support</a>
+            <a href="/home?lang=sv#support">Experience Cloud-Support</a>
           </li>
           <li>
             <a href="https://helpx.adobe.com/support/document-cloud.html"
@@ -189,7 +189,7 @@
       <div>
         <ul>
           <li><a href="https://www.adobe.io/">Adobe I/O</a></li>
-          <li><a href="https://status.adobe.com/">Adobe-status</a></li>
+          <li><a href="https://status.adobe.com/">Adobe-Status</a></li>
         </ul>
       </div>
     </div>
@@ -261,11 +261,6 @@
               >Integritet</a
             >
           </li>
-          <li>
-            <a href="https://www.adobe.com/covid-19-response.html"
-              >COVID-19 Responses</a
-            >
-          </li>
         </ul>
       </div>
     </div>
@@ -315,7 +310,7 @@
           >
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie preferences</a>
+          <a href="#onetrust" title="Cookie preferences">Cookie-inställningar</a>
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >Sälj inte mina personuppgifter</a

--- a/src/converter/static/fragments/zh-hans/footer/footer.html
+++ b/src/converter/static/fragments/zh-hans/footer/footer.html
@@ -298,7 +298,7 @@
     <div>
       <div>
         <p>
-          Copyright © 2024 Adobe. All Rights Reserved. /
+          Copyright © 2025 Adobe. All Rights Reserved. /
           <a href="https://www.adobe.com/go/marketingcloud_privacy">隐私</a>
           /
           <a href="https://www.adobe.com/legal/terms.html">使用条款</a>

--- a/src/converter/static/fragments/zh-hans/footer/footer.html
+++ b/src/converter/static/fragments/zh-hans/footer/footer.html
@@ -48,7 +48,7 @@
             >
           </li>
           <li>
-            <a href="https://helpx.adobe.com/lt/acrobat/using/whats-new.html"
+            <a href="https://helpx.adobe.com/en/acrobat/using/whats-new.html"
               >Document Cloud 发行说明</a
             >
           </li>
@@ -259,11 +259,6 @@
           <li>
             <a href="https://www.adobe.com/about-adobe/integrity.html">诚信</a>
           </li>
-          <li>
-            <a href="https://www.adobe.com/covid-19-response.html"
-              >COVID-19 Responses</a
-            >
-          </li>
         </ul>
       </div>
     </div>
@@ -309,7 +304,7 @@
           <a href="https://www.adobe.com/legal/terms.html">使用条款</a>
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie preferences</a>
+          <a href="#onetrust" title="Cookie preferences">Cookie 首选项</a>
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >请勿出售我的个人信息</a

--- a/src/converter/static/fragments/zh-hant/footer/footer.html
+++ b/src/converter/static/fragments/zh-hant/footer/footer.html
@@ -305,7 +305,7 @@
     <div>
       <div>
         <p>
-          Copyright © 2024 Adobe. All Rights Reserved. /
+          Copyright © 2025 Adobe. All Rights Reserved. /
           <a href="https://www.adobe.com/go/marketingcloud_privacy">隱私權</a>
           /
           <a href="https://www.adobe.com/legal/terms.html">使用條款</a>

--- a/src/converter/static/fragments/zh-hant/footer/footer.html
+++ b/src/converter/static/fragments/zh-hant/footer/footer.html
@@ -311,7 +311,7 @@
           <a href="https://www.adobe.com/legal/terms.html">使用條款</a>
           /
           <!-- Please ensure href="#onetrust" remain unchanged - FE depends on it. -->
-          <a href="#onetrust" title="Cookie preferences">Cookie preferences</a>
+          <a href="#onetrust" title="Cookie preferences">Cookie 偏好設定</a>
           /
           <a href="https://www.adobe.com/privacy/ca-rights.html"
             >不要銷售我的個人資訊</a


### PR DESCRIPTION
1. UGP-8123 [Footer] String "Cookie preferences" is not localized on corresponding locale in Footer
2. UGP-11732 [Documentation][LOC] 'Tutorials' string is unlocalized in footer
3. UGP-9655 [Footer] Strings 'Adobe Developer' and 'COVID-19 Responses' appear unlocalized in footer
4. UGP-8087 [Footer]: Category pages: Community, Support, Adobe  lead to the English locale
5. UGP-8086 [Footer]: "Document Cloud release notes" link lead to page with incorrect locale. 
6. UGP-8089 [Footer]: "Privacy", "Terms of Use", "Do not sell my personal information", "AdChoices" links are leads to pages with incorrect locale
7. UGP-9656 [Footer] Adobe Status product name starts with lowercase letter in footer
8. UGP-9958 [Footer][ESP,PTB] Products name starts with lowercase letter in footer
9. UGP-12469 Update copyright to 2025