### PR TITLE
bugfix/UGP-12701 Remove COVID link from the english footer

### DIFF
--- a/src/converter/static/fragments/en/footer/footer.html
+++ b/src/converter/static/fragments/en/footer/footer.html
@@ -261,11 +261,6 @@
               >Integrity</a
             >
           </li>
-          <li>
-            <a href="https://www.adobe.com/covid-19-response.html"
-              >COVID-19 Responses</a
-            >
-          </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Jira Ticket: UGP-12701

The 'COVID-19 Responses' link in the footer menu, under the 'Adobe' column, points to a non-existent page. It should be removed.