### PR TITLE
fix: (UGP-11508) properly handle whitespacing for highlighted text

### DIFF
--- a/src/converter/modules/blocks/create-highlight.js
+++ b/src/converter/modules/blocks/create-highlight.js
@@ -13,8 +13,13 @@ import {
 const toHighlightedEl = (document, textNode) => {
   const em = document.createElement('em');
   const u = document.createElement('u');
+  const { textContent } = textNode;
+  const prefixSpaces = (textContent.match(/^\s*/) || [''])[0];
+  const suffixSpaces = (textContent.match(/\s*$/) || [''])[0];
+  u.innerHTML = textContent.trim();
+  em.appendChild(document.createTextNode(prefixSpaces));
   em.appendChild(u);
-  u.innerHTML = textNode.textContent;
+  em.appendChild(document.createTextNode(suffixSpaces));
   return em;
 };
 


### PR DESCRIPTION
The helix html2md conversion does not respect suffix/prefix spaces inside a <u>, so we move those spaces to the surrounding <em> instead; helix html2md conversion respects that.