### PR TITLE
feature UGP-8889 Adding applies to block

### DIFF
--- a/src/converter/modules/ExlMd2Html.js
+++ b/src/converter/modules/ExlMd2Html.js
@@ -22,6 +22,7 @@ import createList from './blocks/create-list.js';
 import createArticleMetaData from './blocks/create-article-metadata.js';
 import createArticleMetaDataTopics from './blocks/create-article-metadata-topics.js';
 import createArticleMetaDataCreatedBy from './blocks/create-article-metadata-createdby.js';
+import createArticleMetaDataAppliesTo from './blocks/create-article-metadata-appliesto.js';
 import markdownItToHtml from './MarkdownIt.js';
 import createMiniTOC from './blocks/create-mini-toc.js';
 import createImg from './blocks/create-img.js';
@@ -123,6 +124,7 @@ export default async function md2html({
     createArticleMetaData(document, meta);
     await createArticleMetaDataCreatedBy(document, data, reqLang);
     await createArticleMetaDataTopics(document, meta, reqLang);
+    await createArticleMetaDataAppliesTo(document, meta, reqLang);
 
     // blocks that cannot contain other blocks
     createRelatedArticles(document);

--- a/src/converter/modules/blocks-translated-labels.js
+++ b/src/converter/modules/blocks-translated-labels.js
@@ -28,6 +28,21 @@ export const CREATED_FOR = {
   'zh-hans': '创建对象：',
 };
 
+export const APPLIES_TO = {
+  en: 'Applies to:',
+  de: 'Gilt für:',
+  fr: "S'applique à :",
+  it: 'Si applica a:',
+  sv: 'Gäller:',
+  es: 'Se aplica a:',
+  nl: 'Van toepassing op:',
+  ko: '적용 대상:',
+  ja: '適用対象：',
+  'pt-br': 'Aplica-se a:',
+  'zh-hant': '適用對象：',
+  'zh-hans': '适用对象：',
+};
+
 export const TOPICS = {
   en: 'Topics:',
   de: 'Themen:',

--- a/src/converter/modules/blocks/create-article-metadata-appliesto.js
+++ b/src/converter/modules/blocks/create-article-metadata-appliesto.js
@@ -1,0 +1,34 @@
+import yaml from 'js-yaml';
+import { toBlock, newHtmlList } from '../utils/dom-utils.js';
+import { APPLIES_TO } from '../blocks-translated-labels.js';
+
+export default async function createArticleMetaDataAppliesTo(
+  document,
+  meta,
+  reqLang,
+) {
+  const fullMetadata = yaml.load(meta);
+  const metaElement = document.querySelector('.article-metadata');
+  const version = fullMetadata?.version;
+  // Article Metadata Applies To
+  if (version && version.trim() !== '') {
+    const versionDivTag = document.createElement('div');
+    const appliesToDiv = document.createElement('div');
+    const paragraph = document.createElement('p');
+    paragraph.textContent = APPLIES_TO[reqLang];
+    appliesToDiv.append(paragraph);
+    versionDivTag.append(appliesToDiv);
+
+    const items = [version.trim()];
+
+    versionDivTag.append(
+      newHtmlList(document, {
+        tag: 'ul',
+        items,
+      }),
+    );
+    const cells = [[versionDivTag]];
+    const block = toBlock('article-metadata-appliesto', cells, document);
+    metaElement?.insertAdjacentElement('afterend', block);
+  }
+}

--- a/src/converter/modules/blocks/create-article-metadata-appliesto.js
+++ b/src/converter/modules/blocks/create-article-metadata-appliesto.js
@@ -19,7 +19,7 @@ export default async function createArticleMetaDataAppliesTo(
     appliesToDiv.append(paragraph);
     versionDivTag.append(appliesToDiv);
 
-    const items = [version.trim()];
+    const items = version.split(',').map((item) => item.trim());
 
     versionDivTag.append(
       newHtmlList(document, {


### PR DESCRIPTION
Jira Task UGP-9959

**Description:** Add a new 'Applies to' block on document pages that displays version metadata. The block shows the version information under a localized "APPLIES TO" heading

Testing URLS:

$env/en/docs/internal-test/test/bug-fixes/validation-notes
$env/en/docs/internal-test/test/table-spans
$env/en/docs/internal-test/test/feature-testing/downloads
$env/en/docs/internal-test/test/bug-fixes/zoomable-images-tables
$env/en/docs/internal-test/test/bug-fixes/validation-notes
$env/en/docs/internal-test/test/feature-testing/ugp-11565


