### PR TITLE
Feature/UGP-8889 "Applies to" html structure changed.

### DIFF
--- a/src/converter/modules/blocks/create-article-metadata-appliesto.js
+++ b/src/converter/modules/blocks/create-article-metadata-appliesto.js
@@ -13,20 +13,12 @@ export default async function createArticleMetaDataAppliesTo(
   // Article Metadata Applies To
   if (version && version.trim() !== '') {
     const versionDivTag = document.createElement('div');
-    const appliesToDiv = document.createElement('div');
-    const paragraph = document.createElement('p');
-    paragraph.textContent = APPLIES_TO[reqLang];
-    appliesToDiv.append(paragraph);
-    versionDivTag.append(appliesToDiv);
+    const items = [APPLIES_TO[reqLang]];
 
-    const items = version.split(',').map((item) => item.trim());
+    // Add version items to the list
+    items.push(...version.split(',').map((item) => item.trim()));
 
-    versionDivTag.append(
-      newHtmlList(document, {
-        tag: 'ul',
-        items,
-      }),
-    );
+    versionDivTag.append(newHtmlList(document, { tag: 'ul', items }));
     const cells = [[versionDivTag]];
     const block = toBlock('article-metadata-appliesto', cells, document);
     metaElement?.insertAdjacentElement('afterend', block);


### PR DESCRIPTION
Jira Task UGP-9959

**Description:** Add a new 'Applies to' block on document pages that displays version metadata. The block shows the version information under a localized "APPLIES TO" heading

What Changes: HTML structure to use same css declarations of the topics block

Testing URLS:

$/en/docs/internal-test/test/bug-fixes/validation-notes
$/en/docs/internal-test/test/table-spans
$/en/docs/internal-test/test/feature-testing/downloads
$/en/docs/internal-test/test/bug-fixes/zoomable-images-tables
$/en/docs/internal-test/test/bug-fixes/validation-notes
$/en/docs/internal-test/test/feature-testing/ugp-11565
